### PR TITLE
fix(rpc): harden failover diagnostics and batch handling

### DIFF
--- a/packages/permit2-rpc-server/src/core/head-tracker.ts
+++ b/packages/permit2-rpc-server/src/core/head-tracker.ts
@@ -1,4 +1,5 @@
 import type { RpcMetricsRegistry } from "./rpc-metrics.ts";
+import { getRpcEndpointId, redactRpcDiagnostic } from "./rpc-endpoint-id.ts";
 
 type LoggerFn = (level: "debug" | "info" | "warn" | "error", message: string, ...optionalParams: unknown[]) => void;
 
@@ -42,7 +43,7 @@ export class HeadTracker {
 
   constructor(
     private readonly metrics: RpcMetricsRegistry,
-    options: HeadSamplingOptions = {}
+    options: HeadSamplingOptions = {},
   ) {
     this.now = options.now ?? Date.now;
     this.sampleIntervalMs = options.sampleIntervalMs ?? DEFAULT_SAMPLE_INTERVAL_MS;
@@ -130,7 +131,10 @@ export class HeadTracker {
       return head;
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
-      this.log("debug", `HeadTracker sample failed for ${rpcUrl}: ${err.message}`);
+      this.log(
+        "debug",
+        `HeadTracker sample failed for ${getRpcEndpointId(rpcUrl)}: ${redactRpcDiagnostic(err.message)}`,
+      );
       throw err;
     } finally {
       clearTimeout(timeoutId);

--- a/packages/permit2-rpc-server/src/core/head-tracker_test.ts
+++ b/packages/permit2-rpc-server/src/core/head-tracker_test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import { getRpcEndpointId } from "./rpc-endpoint-id.ts";
+import { HeadTracker } from "./head-tracker.ts";
+import { RpcMetricsRegistry } from "./rpc-metrics.ts";
+
+Deno.test("HeadTracker: redacts RPC URLs from sampling diagnostics", async () => {
+  const rpcUrl = "https://user:super-secret@rpc.example/rpc?apiKey=very-secret";
+  const diagnostics: unknown[][] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (() => Promise.reject(new Error(`Head sample failed for ${rpcUrl}`))) as typeof fetch;
+
+  try {
+    const tracker = new HeadTracker(new RpcMetricsRegistry(), {
+      logger: (...args) => diagnostics.push(args),
+    });
+    await tracker.maybeSampleHeads(1, [rpcUrl]);
+
+    const logged = JSON.stringify(diagnostics);
+    assertEquals(logged.includes(rpcUrl), false);
+    assertEquals(logged.includes("super-secret"), false);
+    assertEquals(logged.includes(getRpcEndpointId(rpcUrl)), true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/permit2-rpc-server/src/core/permit2-rpc-manager.ts
+++ b/packages/permit2-rpc-server/src/core/permit2-rpc-manager.ts
@@ -16,6 +16,7 @@ import type { HedgeConfig } from "./hedged-requester.ts";
 import { isWriteMethod } from "./method-classifier.ts";
 import { ConsensusExecutor } from "./consensus.ts";
 import type { ConsensusConfig, ConsensusOptions } from "./consensus.ts";
+import { getRpcEndpointId, redactRpcDiagnostic } from "./rpc-endpoint-id.ts";
 
 // JSON-RPC error codes as per specification
 const JSON_RPC_ERROR_CODES = {
@@ -28,6 +29,7 @@ const JSON_RPC_ERROR_CODES = {
 
   // Implementation-defined errors start at -32000
   IMPLEMENTATION_DEFINED_START: -32000,
+  IMPLEMENTATION_DEFINED_END: -32099,
 
   // Common provider-specific codes
   EXECUTION_REVERTED: 3,
@@ -59,14 +61,19 @@ const normalizeRpcList = (values: string[] | undefined): string[] => {
 };
 
 class JsonRpcError extends Error {
+  public data?: unknown;
+  public httpStatus?: number;
+
   constructor(
     public code: number,
     message: string,
-    public data?: unknown,
-    public httpStatus?: number
+    data?: unknown,
+    httpStatus?: number,
   ) {
-    super(message);
+    super(redactRpcDiagnostic(message));
     this.name = "JsonRpcError";
+    this.data = redactRpcDiagnostic(data);
+    this.httpStatus = httpStatus;
   }
 }
 
@@ -94,7 +101,12 @@ interface RpcHealthState {
   lastFailureTime: number;
   lastSuccessTime: number;
   temporaryUnavailableUntil?: number;
+  recoveryProbeInFlight?: boolean;
   failureReasons: Map<string, number>; // reason -> count
+}
+
+interface RpcAttemptLease {
+  recoveryProbe: boolean;
 }
 
 // Error classification based on behavior, not strings
@@ -198,9 +210,13 @@ export class Permit2RpcManager {
   private rpcScorerV2: RpcScorerV2;
   private scoringV2Enabled: boolean;
   private hedgedRequester: HedgedRequester;
-  private hedgeConfig: Required<Pick<HedgeConfig, "enabled" | "maxHedges" | "delayMs">> & Pick<HedgeConfig, "quantile" | "minDelayMs" | "maxDelayMs">;
+  private hedgeConfig:
+    & Required<Pick<HedgeConfig, "enabled" | "maxHedges" | "delayMs">>
+    & Pick<HedgeConfig, "quantile" | "minDelayMs" | "maxDelayMs">;
   private headTracker: HeadTracker;
-  private headSampling: Required<Pick<HeadSamplingConfig, "enabled" | "sampleIntervalMs" | "maxRpcsPerSample" | "timeoutMs">>;
+  private headSampling: Required<
+    Pick<HeadSamplingConfig, "enabled" | "sampleIntervalMs" | "maxRpcsPerSample" | "timeoutMs">
+  >;
   private consensusExecutor: ConsensusExecutor;
   private consensus: ConsensusConfig;
 
@@ -281,7 +297,10 @@ export class Permit2RpcManager {
     const messageLevelValue = LOG_LEVEL_HIERARCHY[level];
     if (messageLevelValue >= this.configuredLogLevelValue) {
       const logFn = console[level] || console.log;
-      logFn(`[Permit2RPC:${level}] ${message}`, ...optionalParams);
+      logFn(
+        `[Permit2RPC:${level}] ${redactRpcDiagnostic(message)}`,
+        ...optionalParams.map((value) => redactRpcDiagnostic(value)),
+      );
     }
   }
 
@@ -396,16 +415,18 @@ export class Permit2RpcManager {
         };
       }
 
-      if (code >= JSON_RPC_ERROR_CODES.IMPLEMENTATION_DEFINED_START) {
-        // Provider-specific errors
-        if (code === JSON_RPC_ERROR_CODES.QUOTA_EXCEEDED || code === JSON_RPC_ERROR_CODES.REQUEST_LIMIT) {
-          return {
-            behavior: ErrorBehavior.RETRY_WITH_BACKOFF,
-            reason: "quota_exceeded",
-            isProviderIssue: true,
-          };
-        }
+      if (code === JSON_RPC_ERROR_CODES.QUOTA_EXCEEDED || code === JSON_RPC_ERROR_CODES.REQUEST_LIMIT) {
+        return {
+          behavior: ErrorBehavior.RETRY_WITH_BACKOFF,
+          reason: "quota_exceeded",
+          isProviderIssue: true,
+        };
+      }
 
+      if (
+        code <= JSON_RPC_ERROR_CODES.IMPLEMENTATION_DEFINED_START &&
+        code >= JSON_RPC_ERROR_CODES.IMPLEMENTATION_DEFINED_END
+      ) {
         // Other implementation-defined errors are usually retryable
         return {
           behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
@@ -483,16 +504,46 @@ export class Permit2RpcManager {
   private isRpcAvailable(rpcUrl: string): boolean {
     const state = this.getHealthState(rpcUrl);
 
-    if (state.temporaryUnavailableUntil) {
-      const now = Date.now();
-      if (now < state.temporaryUnavailableUntil) {
-        return false;
-      }
-      // Backoff expired, clear it
-      state.temporaryUnavailableUntil = undefined;
+    if (typeof state.temporaryUnavailableUntil === "number" && Date.now() < state.temporaryUnavailableUntil) {
+      return false;
     }
 
-    return state.consecutiveFailures < this.maxConsecutiveFailures;
+    // Endpoints become candidates after their backoff; the attempt lease below
+    // admits only one recovery probe for that completed backoff window.
+    return true;
+  }
+
+  /**
+   * Acquires the single half-open probe permitted for an endpoint after backoff.
+   */
+  private acquireRpcAttempt(rpcUrl: string): RpcAttemptLease | null {
+    const state = this.getHealthState(rpcUrl);
+    const backoffUntil = state.temporaryUnavailableUntil;
+
+    if (typeof backoffUntil === "number" && Date.now() < backoffUntil) {
+      return null;
+    }
+
+    // A completed backoff window is half-open: exactly one request may test
+    // the endpoint, regardless of how many failures started that backoff.
+    if (typeof backoffUntil === "number" && backoffUntil > 0) {
+      if (state.recoveryProbeInFlight) {
+        return null;
+      }
+
+      state.recoveryProbeInFlight = true;
+      this._log("debug", `[HEALTH] Admitting recovery probe for ${getRpcEndpointId(rpcUrl)}`);
+      return { recoveryProbe: true };
+    }
+
+    return { recoveryProbe: false };
+  }
+
+  private releaseRpcAttempt(rpcUrl: string, lease: RpcAttemptLease): void {
+    if (!lease.recoveryProbe) return;
+
+    const state = this.getHealthState(rpcUrl);
+    state.recoveryProbeInFlight = false;
   }
 
   /**
@@ -500,16 +551,19 @@ export class Permit2RpcManager {
    */
   private async recordSuccess(chainId: number, rpcUrl: string): Promise<void> {
     const state = this.getHealthState(rpcUrl);
+    const hadFailures = state.lastFailureTime > 0;
 
     state.consecutiveFailures = 0;
+    state.lastFailureTime = 0;
     state.lastSuccessTime = Date.now();
     state.temporaryUnavailableUntil = undefined;
+    state.recoveryProbeInFlight = false;
     state.failureReasons.clear();
 
-    this._log("debug", `[HEALTH] RPC ${rpcUrl} marked healthy`);
+    this._log("debug", `[HEALTH] RPC ${getRpcEndpointId(rpcUrl)} marked healthy`);
 
     // Update KV if we had failures before
-    if (state.lastFailureTime > 0) {
+    if (hadFailures) {
       try {
         const kv = await Deno.openKv();
         const failureKey = ["rpc_failures", chainId, rpcUrl];
@@ -528,6 +582,7 @@ export class Permit2RpcManager {
 
     state.consecutiveFailures++;
     state.lastFailureTime = Date.now();
+    state.recoveryProbeInFlight = false;
 
     // Track failure reasons
     const count = state.failureReasons.get(classification.reason) || 0;
@@ -540,7 +595,10 @@ export class Permit2RpcManager {
 
       this._log(
         "warn",
-        `[HEALTH] RPC ${rpcUrl} entering backoff for ${backoffMs}ms due to ${classification.reason} ` + `(${state.consecutiveFailures} consecutive failures)`
+        `[HEALTH] RPC ${
+          getRpcEndpointId(rpcUrl)
+        } entering backoff for ${backoffMs}ms due to ${classification.reason} ` +
+          `(${state.consecutiveFailures} consecutive failures)`,
       );
     } else if (state.consecutiveFailures >= this.maxConsecutiveFailures) {
       // Mark as unavailable for longer period
@@ -548,10 +606,12 @@ export class Permit2RpcManager {
 
       this._log(
         "warn",
-        `[HEALTH] RPC ${rpcUrl} marked unhealthy after ${state.consecutiveFailures} failures. ` +
-          `Reasons: ${Array.from(state.failureReasons.entries())
-            .map(([r, c]) => `${r}:${c}`)
-            .join(", ")}`
+        `[HEALTH] RPC ${getRpcEndpointId(rpcUrl)} marked unhealthy after ${state.consecutiveFailures} failures. ` +
+          `Reasons: ${
+            Array.from(state.failureReasons.entries())
+              .map(([r, c]) => `${r}:${c}`)
+              .join(", ")
+          }`,
       );
     }
 
@@ -570,13 +630,27 @@ export class Permit2RpcManager {
     }
   }
 
+  private allRpcsFailedError(chainId: number, attemptedRpcs: string[], lastError: Error | null): JsonRpcError {
+    const attemptedRpcIds = attemptedRpcs.map((rpcUrl) => getRpcEndpointId(rpcUrl));
+    const errorMsg = redactRpcDiagnostic(lastError?.message || "Unknown error");
+
+    return new JsonRpcError(
+      -32000,
+      `All ${attemptedRpcIds.length} RPC endpoints failed for chain ${chainId}. ` +
+        `Attempted: [${attemptedRpcIds.join(", ")}]. Last error: ${errorMsg}`,
+      { attemptedRpcIds, chainId },
+    );
+  }
+
   /**
    * Send a JSON-RPC request with intelligent failover
    */
   send<T = unknown>(chainId: number, method: string, params: unknown[] = [], options?: SendOptions): Promise<T> {
     const normalizedOverrides = normalizeRpcList(options?.rpcOverrides);
     const allowFallback = Boolean(options?.allowFallback);
-    const overrideKey = normalizedOverrides.length > 0 ? `|override=${normalizedOverrides.join(",")}|fallback=${allowFallback ? "1" : "0"}` : "";
+    const overrideKey = normalizedOverrides.length > 0
+      ? `|override=${normalizedOverrides.join(",")}|fallback=${allowFallback ? "1" : "0"}`
+      : "";
 
     // Use request deduplication for identical concurrent requests
     const deduplicationKey = `${RequestDeduplicator.generateKey(chainId, method, params)}${overrideKey}`;
@@ -592,7 +666,12 @@ export class Permit2RpcManager {
   /**
    * Internal send implementation (after deduplication)
    */
-  private async _sendInternal<T = unknown>(chainId: number, method: string, params: unknown[], options?: SendOptions): Promise<T> {
+  private async _sendInternal<T = unknown>(
+    chainId: number,
+    method: string,
+    params: unknown[],
+    options?: SendOptions,
+  ): Promise<T> {
     const allRpcs = await this.rpcSelector.getRankedRpcList(chainId);
     const rpcByNormalized = new Map(allRpcs.map((rpc) => [normalizeRpcUrl(rpc), rpc]));
     const overrideRequested = options?.rpcOverrides && options.rpcOverrides.length > 0;
@@ -621,7 +700,8 @@ export class Permit2RpcManager {
       if (rpcs.length > 0) {
         this._log(
           "debug",
-          `[CAPABILITIES] All candidate RPCs are marked unsupported for ${method} on chain ${chainId}; ` + `proceeding without capability filtering.`
+          `[CAPABILITIES] All candidate RPCs are marked unsupported for ${method} on chain ${chainId}; ` +
+            `proceeding without capability filtering.`,
         );
       }
 
@@ -639,14 +719,13 @@ export class Permit2RpcManager {
     const overrideSet = new Set(healthyOverrides);
 
     if (overrideRequested && !hasOverride) {
-      const message =
-        overrideCandidates.length > 0
-          ? "Override RPCs are currently unavailable (health checks or circuit breaker)."
-          : "No override RPCs matched the configured whitelist.";
+      const message = overrideCandidates.length > 0
+        ? "Override RPCs are currently unavailable (health checks or circuit breaker)."
+        : "No override RPCs matched the configured whitelist.";
       if (!allowFallback) {
         throw new JsonRpcError(JSON_RPC_ERROR_CODES.INVALID_PARAMS, message, {
           chainId,
-          provided: options?.rpcOverrides ?? [],
+          providedRpcIds: (options?.rpcOverrides ?? []).map((rpcUrl) => getRpcEndpointId(rpcUrl)),
         });
       }
       this._log("warn", `[SEND] ${message} Falling back to default selection for chain ${chainId}.`);
@@ -660,38 +739,48 @@ export class Permit2RpcManager {
       }).length;
 
       if (backoffCount > 0) {
-        throw new Error(`All ${backoffCount} RPC endpoints are temporarily unavailable for chain ${chainId}. ` + `Please retry in a few seconds.`);
+        throw new Error(
+          `All ${backoffCount} RPC endpoints are temporarily unavailable for chain ${chainId}. ` +
+            `Please retry in a few seconds.`,
+        );
       }
 
       const circuitBlockedCount = allRpcs.filter((rpc) => !this.circuitBreaker.canRequest(rpc)).length;
       if (allRpcs.length > 0 && circuitBlockedCount === allRpcs.length) {
         throw new Error(
           `All ${circuitBlockedCount} RPC endpoints are temporarily unavailable for chain ${chainId} ` +
-            `(circuit breaker open). Please retry in a few seconds.`
+            `(circuit breaker open). Please retry in a few seconds.`,
         );
       }
 
       // Emergency fallback: Reset all RPC health states and retry with full list
       this._log(
         "warn",
-        `[EMERGENCY FALLBACK] No healthy RPCs available for chain ${chainId}. ` + `Resetting all RPC health states and retrying with full list.`
+        `[EMERGENCY FALLBACK] No healthy RPCs available for chain ${chainId}. ` +
+          `Resetting all RPC health states and retrying with full list.`,
       );
 
       // Reset all RPC health states for this chain
       await this.resetAllRpcHealthStates(chainId, allRpcs);
 
       // Re-filter available RPCs after reset
-      const resetAvailableRpcs = allRpcs.filter((rpc) => this.isRpcAvailable(rpc) && this.circuitBreaker.canRequest(rpc));
+      const resetAvailableRpcs = allRpcs.filter((rpc) =>
+        this.isRpcAvailable(rpc) && this.circuitBreaker.canRequest(rpc)
+      );
 
       if (resetAvailableRpcs.length > 0) {
         // Continue with the reset RPCs - update rankedRpcs for the rest of the method
         rankedRpcs = rankCandidates(getCandidates(resetAvailableRpcs));
 
-        this._log("info", `[EMERGENCY FALLBACK] Found ${resetAvailableRpcs.length} available RPCs for chain ${chainId} after reset`);
+        this._log(
+          "info",
+          `[EMERGENCY FALLBACK] Found ${resetAvailableRpcs.length} available RPCs for chain ${chainId} after reset`,
+        );
       } else {
         // If still no RPCs available after reset, this is a configuration issue
         throw new Error(
-          `No RPC endpoints configured or all endpoints are fundamentally unreachable for chain ${chainId}. ` + `Please check your RPC configuration.`
+          `No RPC endpoints configured or all endpoints are fundamentally unreachable for chain ${chainId}. ` +
+            `Please check your RPC configuration.`,
         );
       }
     }
@@ -707,7 +796,7 @@ export class Permit2RpcManager {
         "info",
         `[SEND] Using override RPCs for chain ${chainId}. ` +
           `Overrides=${healthyOverrides.length}, allowFallback=${allowFallback}, fallbackCount=${rankedFallback.length}.`,
-        { overrides: healthyOverrides, fallback: rankedFallback }
+        { overrides: healthyOverrides, fallback: rankedFallback },
       );
     } else {
       // Round-robin selection from ranked RPCs
@@ -715,13 +804,19 @@ export class Permit2RpcManager {
       startIndex = currentIndex % rankedRpcs.length;
       this.rpcIndexMap.set(chainId, (currentIndex + 1) % rankedRpcs.length);
 
-      this._log("debug", `[SEND] Chain ${chainId}: ${rankedRpcs.length}/${allRpcs.length} RPCs available. ` + `Starting at index ${startIndex}.`);
+      this._log(
+        "debug",
+        `[SEND] Chain ${chainId}: ${rankedRpcs.length}/${allRpcs.length} RPCs available. ` +
+          `Starting at index ${startIndex}.`,
+      );
 
       orderedRpcs = rankedRpcs.slice(startIndex).concat(rankedRpcs.slice(0, startIndex));
     }
 
     if (orderedRpcs.length === 0) {
-      throw new JsonRpcError(JSON_RPC_ERROR_CODES.INTERNAL_ERROR, `No RPC endpoints available for chain ${chainId}.`, { chainId });
+      throw new JsonRpcError(JSON_RPC_ERROR_CODES.INTERNAL_ERROR, `No RPC endpoints available for chain ${chainId}.`, {
+        chainId,
+      });
     }
 
     let lastError: Error | null = null;
@@ -729,7 +824,8 @@ export class Permit2RpcManager {
 
     const normalizedMethod = method.trim().toLowerCase();
 
-    const consensusEnabled = this.consensus.enabled && !isWriteMethod(method) && this.consensus.methods.includes(normalizedMethod) && orderedRpcs.length > 1;
+    const consensusEnabled = this.consensus.enabled && !isWriteMethod(method) &&
+      this.consensus.methods.includes(normalizedMethod) && orderedRpcs.length > 1;
 
     if (consensusEnabled) {
       try {
@@ -762,11 +858,20 @@ export class Permit2RpcManager {
               }
 
               const classification = this.classifyError(err);
-              const circuitClassification = classification.reason === "method_not_found" ? { ...classification, isProviderIssue: false } : classification;
+              const circuitClassification = classification.reason === "method_not_found"
+                ? { ...classification, isProviderIssue: false }
+                : classification;
 
-              this._log("warn", `[SEND] RPC ${rpcUrl} failed: ${classification.reason} ` + `(behavior: ${ErrorBehavior[classification.behavior]})`);
+              this._log(
+                "warn",
+                `[SEND] RPC ${rpcUrl} failed: ${classification.reason} ` +
+                  `(behavior: ${ErrorBehavior[classification.behavior]})`,
+              );
 
-              if (classification.behavior === ErrorBehavior.DO_NOT_RETRY || classification.behavior === ErrorBehavior.BLOCKCHAIN_ERROR) {
+              if (
+                classification.behavior === ErrorBehavior.DO_NOT_RETRY ||
+                classification.behavior === ErrorBehavior.BLOCKCHAIN_ERROR
+              ) {
                 this.circuitBreaker.recordResult(rpcUrl, circuitClassification, false);
                 throw err;
               }
@@ -780,22 +885,20 @@ export class Permit2RpcManager {
               throw err;
             }
           },
-          this.consensus
+          this.consensus,
         );
       } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error));
         const classification = this.classifyError(err);
 
-        if (classification.behavior === ErrorBehavior.DO_NOT_RETRY || classification.behavior === ErrorBehavior.BLOCKCHAIN_ERROR) {
+        if (
+          classification.behavior === ErrorBehavior.DO_NOT_RETRY ||
+          classification.behavior === ErrorBehavior.BLOCKCHAIN_ERROR
+        ) {
           throw err;
         }
 
-        const errorMsg = err.message || "Unknown error";
-        throw new JsonRpcError(
-          -32000,
-          `All ${attemptedRpcs.length} RPC endpoints failed for chain ${chainId}. ` + `Attempted: [${attemptedRpcs.join(", ")}]. Last error: ${errorMsg}`,
-          { attemptedRpcs, chainId }
-        );
+        throw this.allRpcsFailedError(chainId, attemptedRpcs, lastError ?? err);
       }
     }
 
@@ -859,15 +962,25 @@ export class Permit2RpcManager {
               }
 
               const classification = this.classifyError(err);
-              const circuitClassification = classification.reason === "method_not_found" ? { ...classification, isProviderIssue: false } : classification;
+              const circuitClassification = classification.reason === "method_not_found"
+                ? { ...classification, isProviderIssue: false }
+                : classification;
 
-              this._log("warn", `[SEND] RPC ${rpcUrl} failed: ${classification.reason} ` + `(behavior: ${ErrorBehavior[classification.behavior]})`);
+              this._log(
+                "warn",
+                `[SEND] RPC ${rpcUrl} failed: ${classification.reason} ` +
+                  `(behavior: ${ErrorBehavior[classification.behavior]})`,
+              );
 
-              if (classification.behavior === ErrorBehavior.DO_NOT_RETRY || classification.behavior === ErrorBehavior.BLOCKCHAIN_ERROR) {
+              if (
+                classification.behavior === ErrorBehavior.DO_NOT_RETRY ||
+                classification.behavior === ErrorBehavior.BLOCKCHAIN_ERROR
+              ) {
                 this.circuitBreaker.recordResult(rpcUrl, circuitClassification, false);
                 this._log(
                   "info",
-                  `[SEND] Error type ${ErrorBehavior[classification.behavior]} detected. ` + `Not recording as RPC failure to prevent cascade.`
+                  `[SEND] Error type ${ErrorBehavior[classification.behavior]} detected. ` +
+                    `Not recording as RPC failure to prevent cascade.`,
                 );
                 throw new HedgedNonRetryableError(err);
               }
@@ -882,29 +995,28 @@ export class Permit2RpcManager {
               throw err;
             }
           },
-          { maxHedges: this.hedgeConfig.maxHedges, delayMs: hedgeDelayMs }
+          { maxHedges: this.hedgeConfig.maxHedges, delayMs: hedgeDelayMs },
         );
       } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error));
         const classification = this.classifyError(err);
 
-        if (classification.behavior === ErrorBehavior.DO_NOT_RETRY || classification.behavior === ErrorBehavior.BLOCKCHAIN_ERROR) {
+        if (
+          classification.behavior === ErrorBehavior.DO_NOT_RETRY ||
+          classification.behavior === ErrorBehavior.BLOCKCHAIN_ERROR
+        ) {
           throw err;
         }
 
-        const errorMsg = err.message || "Unknown error";
-        throw new JsonRpcError(
-          -32000,
-          `All ${attemptedRpcs.length} RPC endpoints failed for chain ${chainId}. ` + `Attempted: [${attemptedRpcs.join(", ")}]. Last error: ${errorMsg}`,
-          { attemptedRpcs, chainId }
-        );
+        throw this.allRpcsFailedError(chainId, attemptedRpcs, lastError ?? err);
       }
     }
 
-    // Try each available RPC
-    for (let i = 0; i < rankedRpcs.length; i++) {
-      const rpcIndex = (startIndex + i) % rankedRpcs.length;
-      const rpcUrl = rankedRpcs[rpcIndex];
+    // Try the ordered candidate list. This keeps supported override ordering
+    // authoritative for ordinary sequential execution.
+    for (const rpcUrl of orderedRpcs) {
+      const attemptLease = this.acquireRpcAttempt(rpcUrl);
+      if (!attemptLease) continue;
 
       attemptedRpcs.push(rpcUrl);
 
@@ -932,18 +1044,29 @@ export class Permit2RpcManager {
 
         // Classify the error
         const classification = this.classifyError(lastError);
-        const circuitClassification = classification.reason === "method_not_found" ? { ...classification, isProviderIssue: false } : classification;
+        const circuitClassification = classification.reason === "method_not_found"
+          ? { ...classification, isProviderIssue: false }
+          : classification;
 
-        this._log("warn", `[SEND] RPC ${rpcUrl} failed: ${classification.reason} ` + `(behavior: ${ErrorBehavior[classification.behavior]})`);
+        this._log(
+          "warn",
+          `[SEND] RPC ${rpcUrl} failed: ${classification.reason} ` +
+            `(behavior: ${ErrorBehavior[classification.behavior]})`,
+        );
 
         // Decide if we should continue trying other RPCs
         switch (classification.behavior) {
           case ErrorBehavior.DO_NOT_RETRY:
           case ErrorBehavior.BLOCKCHAIN_ERROR:
+            this.releaseRpcAttempt(rpcUrl, attemptLease);
             this.circuitBreaker.recordResult(rpcUrl, circuitClassification, false);
             // These are client/request errors that will be the same on all RPCs
             // Don't record as failures to prevent cascading health issues
-            this._log("info", `[SEND] Error type ${ErrorBehavior[classification.behavior]} detected. ` + `Not recording as RPC failure to prevent cascade.`);
+            this._log(
+              "info",
+              `[SEND] Error type ${ErrorBehavior[classification.behavior]} detected. ` +
+                `Not recording as RPC failure to prevent cascade.`,
+            );
             throw lastError;
 
           case ErrorBehavior.RETRY_WITH_BACKOFF:
@@ -953,6 +1076,8 @@ export class Permit2RpcManager {
               // These are RPC-specific issues that should count toward health
               await this.recordFailure(chainId, rpcUrl, classification);
               this.rpcScorer.updateScore(rpcUrl, false);
+            } else {
+              this.releaseRpcAttempt(rpcUrl, attemptLease);
             }
             this.circuitBreaker.recordResult(rpcUrl, circuitClassification, false);
             // Continue to next RPC
@@ -962,18 +1087,18 @@ export class Permit2RpcManager {
     }
 
     // All RPCs failed
-    const errorMsg = lastError?.message || "Unknown error";
-    throw new JsonRpcError(
-      -32000,
-      `All ${attemptedRpcs.length} RPC endpoints failed for chain ${chainId}. ` + `Attempted: [${attemptedRpcs.join(", ")}]. Last error: ${errorMsg}`,
-      { attemptedRpcs, chainId }
-    );
+    throw this.allRpcsFailedError(chainId, attemptedRpcs, lastError);
   }
 
   /**
    * Execute a single RPC call
    */
-  public async executeRpcCall<T = unknown>(url: string, method: string, params: unknown[], options: { signal?: AbortSignal } = {}): Promise<T> {
+  public async executeRpcCall<T = unknown>(
+    url: string,
+    method: string,
+    params: unknown[],
+    options: { signal?: AbortSignal } = {},
+  ): Promise<T> {
     const controller = new AbortController();
     // Use adaptive timeout if available, otherwise default
     const timeout = this.adaptiveTimeout.getTimeout(url, this.requestTimeoutMs);
@@ -1019,7 +1144,12 @@ export class Permit2RpcManager {
       try {
         responseData = await response.json();
       } catch (_jsonError) {
-        throw new JsonRpcError(JSON_RPC_ERROR_CODES.PARSE_ERROR, `Invalid JSON response from provider`, undefined, response.status);
+        throw new JsonRpcError(
+          JSON_RPC_ERROR_CODES.PARSE_ERROR,
+          `Invalid JSON response from provider`,
+          undefined,
+          response.status,
+        );
       }
 
       // Check for JSON-RPC error
@@ -1028,13 +1158,18 @@ export class Permit2RpcManager {
           responseData.error.code || JSON_RPC_ERROR_CODES.INTERNAL_ERROR,
           responseData.error.message || "RPC error",
           responseData.error.data,
-          response.status
+          response.status,
         );
       }
 
       // Check HTTP status after parsing (some providers return errors as 200 OK)
       if (!response.ok) {
-        throw new JsonRpcError(JSON_RPC_ERROR_CODES.INTERNAL_ERROR, `HTTP error ${response.status} ${response.statusText}`, undefined, response.status);
+        throw new JsonRpcError(
+          JSON_RPC_ERROR_CODES.INTERNAL_ERROR,
+          `HTTP error ${response.status} ${response.statusText}`,
+          undefined,
+          response.status,
+        );
       }
 
       return responseData.result as T;
@@ -1049,7 +1184,12 @@ export class Permit2RpcManager {
         if (controller.signal.reason && controller.signal.reason !== "timeout") {
           throw error;
         }
-        throw new JsonRpcError(JSON_RPC_ERROR_CODES.INTERNAL_ERROR, `Request timeout after ${this.requestTimeoutMs}ms`, undefined, 408);
+        throw new JsonRpcError(
+          JSON_RPC_ERROR_CODES.INTERNAL_ERROR,
+          `Request timeout after ${this.requestTimeoutMs}ms`,
+          undefined,
+          408,
+        );
       }
 
       throw error;
@@ -1067,7 +1207,7 @@ export class Permit2RpcManager {
         // Process each chunk with some parallelism but not all at once
         const results = await Promise.all(batch.map((req) => this.send<T>(chainId, req.method, req.params)));
         return results;
-      }
+      },
     );
   }
 
@@ -1087,7 +1227,8 @@ export class Permit2RpcManager {
         consecutiveFailures: 0,
         lastFailureTime: -1,
         lastSuccessTime: Date.now(),
-        temporaryUnavailableUntil: -1,
+        temporaryUnavailableUntil: undefined,
+        recoveryProbeInFlight: false,
         failureReasons: new Map(),
       });
 
@@ -1097,9 +1238,9 @@ export class Permit2RpcManager {
         const failureKey = ["rpc_failures", chainId, rpcUrl];
         await kv.delete(failureKey);
 
-        this._log("debug", `[HEALTH RESET] Cleared KV state for ${rpcUrl}`);
+        this._log("debug", `[HEALTH RESET] Cleared KV state for ${getRpcEndpointId(rpcUrl)}`);
       } catch (error) {
-        this._log("error", `[HEALTH RESET] Failed to clear KV state for ${rpcUrl}:`, error);
+        this._log("error", `[HEALTH RESET] Failed to clear KV state for ${getRpcEndpointId(rpcUrl)}:`, error);
       }
     }
 
@@ -1152,14 +1293,14 @@ export class Permit2RpcManager {
         // Get cached latency data if available
         const chainCache = cacheData?.[chainId];
         if (chainCache?.latencyMap) {
-          chainData.fastestRpc = chainCache.fastestRpc;
+          chainData.fastestRpc = chainCache.fastestRpc ? getRpcEndpointId(chainCache.fastestRpc) : null;
           chainData.lastTested = chainCache.lastTested;
         }
 
         // Process each RPC
         for (const rpcUrl of rpcUrls) {
           const rpcInfo: any = {
-            url: rpcUrl,
+            endpointId: getRpcEndpointId(rpcUrl),
             status: "unknown",
             healthy: false,
           };
@@ -1170,13 +1311,13 @@ export class Permit2RpcManager {
             rpcInfo.consecutiveFailures = healthState.consecutiveFailures;
             rpcInfo.lastFailureTime = healthState.lastFailureTime > 0 ? healthState.lastFailureTime : null;
             rpcInfo.lastSuccessTime = healthState.lastSuccessTime > 0 ? healthState.lastSuccessTime : null;
+            rpcInfo.recoveryProbeInFlight = Boolean(healthState.recoveryProbeInFlight);
 
             // Check if eliminated
             if (healthState.consecutiveFailures >= this.maxConsecutiveFailures) {
-              const backoffMs = Math.min(this.backoffBaseMs * Math.pow(2, healthState.consecutiveFailures - this.maxConsecutiveFailures), this.maxBackoffMs);
-              const nextRetryTime = healthState.lastFailureTime + backoffMs;
+              const nextRetryTime = healthState.temporaryUnavailableUntil;
 
-              if (Date.now() < nextRetryTime) {
+              if (typeof nextRetryTime === "number" && Date.now() < nextRetryTime) {
                 rpcInfo.status = "eliminated";
                 rpcInfo.nextRetryAt = nextRetryTime;
                 chainData.eliminatedRpcs++;
@@ -1261,7 +1402,12 @@ export class Permit2RpcManager {
   /**
    * Perform a Multicall3 batch of read-only eth_call requests.
    */
-  async multicall3(chainId: number, requests: Multicall3Request[], blockTag: string | number = "latest", options?: SendOptions): Promise<JsonRpcResponse[]> {
+  async multicall3(
+    chainId: number,
+    requests: Multicall3Request[],
+    blockTag: string | number = "latest",
+    options?: SendOptions,
+  ): Promise<JsonRpcResponse[]> {
     if (requests.length === 0) {
       return [];
     }
@@ -1279,14 +1425,16 @@ export class Permit2RpcManager {
       const uniqueRequests = requests.filter(
         (req, index, self) =>
           index ===
-          self.findIndex(
-            (r) => r.params[0].to.toLowerCase() === req.params[0].to.toLowerCase() && r.params[0].data.toLowerCase() === req.params[0].data.toLowerCase()
-          )
+            self.findIndex(
+              (r) =>
+                r.params[0].to.toLowerCase() === req.params[0].to.toLowerCase() &&
+                r.params[0].data.toLowerCase() === req.params[0].data.toLowerCase(),
+            ),
       );
 
       this._log(
         "info",
-        `Performing multicall3 with ${uniqueRequests.length} unique calls for ${requests.length} requests on chain ${chainId} with block tag '${blockTag}'`
+        `Performing multicall3 with ${uniqueRequests.length} unique calls for ${requests.length} requests on chain ${chainId} with block tag '${blockTag}'`,
       );
 
       const viemCalls = uniqueRequests.map((c) => ({
@@ -1312,7 +1460,7 @@ export class Permit2RpcManager {
           },
           blockTag,
         ],
-        options
+        options,
       );
 
       const decodedResult = decodeFunctionResult({
@@ -1344,7 +1492,9 @@ export class Permit2RpcManager {
         .filter((req) => !uniqueRequests.map((r) => r.id).includes(req.id))
         .map((req) => {
           const requestIndex = uniqueRequests.findIndex(
-            (r) => r.params[0].to.toLowerCase() === req.params[0].to.toLowerCase() && r.params[0].data.toLowerCase() === req.params[0].data.toLowerCase()
+            (r) =>
+              r.params[0].to.toLowerCase() === req.params[0].to.toLowerCase() &&
+              r.params[0].data.toLowerCase() === req.params[0].data.toLowerCase(),
           );
           const response = structuredClone(uniqueResponses[requestIndex]);
           response.id = req.id;
@@ -1354,9 +1504,11 @@ export class Permit2RpcManager {
       return [...uniqueResponses, ...duplicatedResponses];
     } catch (e) {
       const error = e instanceof Error ? e : new Error(String(e));
-      console.error(`Error processing multicall3 batch for chain ${chainId}:`, error);
+      this._log("error", `Error processing multicall3 batch for chain ${chainId}:`, error);
 
-      const code = error.name === "JsonRpcError" && "code" in error && typeof error.code === "number" ? error.code : -32603;
+      const code = error.name === "JsonRpcError" && "code" in error && typeof error.code === "number"
+        ? error.code
+        : -32603;
       const data = "data" in error ? error.data : undefined;
 
       return requests.map((req) => ({
@@ -1364,8 +1516,8 @@ export class Permit2RpcManager {
         id: req.id,
         error: {
           code,
-          message: error.message,
-          data,
+          message: redactRpcDiagnostic(error.message),
+          data: redactRpcDiagnostic(data),
         },
       }));
     }

--- a/packages/permit2-rpc-server/src/core/permit2-rpc-manager_hardening_test.ts
+++ b/packages/permit2-rpc-server/src/core/permit2-rpc-manager_hardening_test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { getRpcEndpointId } from "./rpc-endpoint-id.ts";
+import { Permit2RpcManager } from "./permit2-rpc-manager.ts";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json", ...(init.headers ?? {}) },
+  });
+}
+
+function inputUrl(input: RequestInfo | URL): string {
+  return typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+}
+
+function installOpenKvMock(): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(Deno, "openKv");
+  if (!descriptor) throw new Error("Deno.openKv descriptor is unavailable");
+
+  Object.defineProperty(Deno, "openKv", {
+    configurable: descriptor.configurable,
+    enumerable: descriptor.enumerable,
+    writable: true,
+    value: (() =>
+      Promise.resolve({
+        set: async () => {},
+        delete: async () => {},
+        close: () => {},
+      } as unknown as Deno.Kv)) as typeof Deno.openKv,
+  });
+
+  return () => Object.defineProperty(Deno, "openKv", descriptor);
+}
+
+function createManager(
+  rpcs: string[],
+  options: ConstructorParameters<typeof Permit2RpcManager>[0] = {},
+): Permit2RpcManager {
+  const manager = new Permit2RpcManager({
+    initialRpcData: { rpcs: { "1": rpcs } },
+    disableCache: true,
+    logLevel: "none",
+    scoringV2: { enabled: false },
+    ...options,
+  });
+  manager.rpcSelector.getRankedRpcList = () => Promise.resolve(rpcs);
+  (manager as any).rpcScorer.getRankedRpcs = (candidates: string[]) => candidates;
+  return manager;
+}
+
+for (const quotaCode of [-32004, -32005]) {
+  Deno.test(`quota code ${quotaCode} fails over to a healthy endpoint`, async () => {
+    const quotaRpc = "https://quota.example";
+    const healthyRpc = "https://healthy.example";
+    const manager = createManager([quotaRpc, healthyRpc]);
+    const restoreOpenKv = installOpenKvMock();
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+
+    globalThis.fetch = ((input) => {
+      const url = inputUrl(input);
+      calls.push(url);
+      if (url === quotaRpc) {
+        return Promise.resolve(
+          jsonResponse({ jsonrpc: "2.0", id: 1, error: { code: quotaCode, message: "quota exhausted" } }),
+        );
+      }
+      return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "healthy-result" }));
+    }) as typeof fetch;
+
+    try {
+      assert.equal(await manager.send(1, "eth_blockNumber"), "healthy-result");
+      assert.deepEqual(calls, [quotaRpc, healthyRpc]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreOpenKv();
+    }
+  });
+}
+
+Deno.test("invalid params and deterministic execution errors do not retry", async () => {
+  const firstRpc = "https://first.example";
+  const secondRpc = "https://second.example";
+  const manager = createManager([firstRpc, secondRpc]);
+  const originalFetch = globalThis.fetch;
+
+  try {
+    for (
+      const error of [
+        { code: -32602, message: "invalid params" },
+        { code: 3, message: "execution reverted" },
+      ]
+    ) {
+      const calls: string[] = [];
+      (manager as any).rpcIndexMap.set(1, 0);
+      globalThis.fetch = ((input) => {
+        calls.push(inputUrl(input));
+        return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, error }));
+      }) as typeof fetch;
+
+      await assert.rejects(() => manager.send(1, "eth_call", []));
+      assert.deepEqual(calls, [firstRpc]);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("a backed-off endpoint admits one recovery probe and resets after success", async () => {
+  const rpc = "https://recover.example";
+  const manager = createManager([rpc], {
+    maxConsecutiveFailures: 3,
+    backoffBaseMs: 5,
+    maxBackoffMs: 10,
+  });
+  const restoreOpenKv = installOpenKvMock();
+  const originalFetch = globalThis.fetch;
+  const originalNowDescriptor = Object.getOwnPropertyDescriptor(Date, "now");
+  if (!originalNowDescriptor) throw new Error("Date.now descriptor is unavailable");
+  let now = 10_000;
+  let phase: "initial-backoff" | "recovery" | "healthy" = "initial-backoff";
+  let resolveRecovery!: (response: Response) => void;
+  let signalRecoveryFetch!: () => void;
+  const recoveryResponse = new Promise<Response>((resolve) => {
+    resolveRecovery = resolve;
+  });
+  const recoveryFetchStarted = new Promise<void>((resolve) => {
+    signalRecoveryFetch = resolve;
+  });
+  const calls: string[] = [];
+
+  Object.defineProperty(Date, "now", { ...originalNowDescriptor, value: () => now });
+  globalThis.fetch = ((input) => {
+    calls.push(inputUrl(input));
+    if (phase === "initial-backoff") {
+      return Promise.resolve(
+        jsonResponse({ jsonrpc: "2.0", id: 1, error: { code: -32004, message: "quota exhausted" } }),
+      );
+    }
+    if (phase === "recovery") {
+      signalRecoveryFetch();
+      return recoveryResponse;
+    }
+    return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "healthy" }));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(() => manager.send(1, "eth_blockNumber", ["initial"]));
+    assert.equal(calls.length, 1);
+
+    now = 10_004;
+    await assert.rejects(() => manager.send(1, "eth_blockNumber", ["before-expiry"]));
+    assert.equal(calls.length, 1, "backoff must block network traffic before expiry");
+
+    now = 10_006;
+    phase = "recovery";
+    const firstRecovery = manager.send<string>(1, "eth_blockNumber", ["first-recovery"]);
+    await recoveryFetchStarted;
+
+    await assert.rejects(() => manager.send(1, "eth_blockNumber", ["second-recovery"]));
+    assert.equal(calls.length, 2, "concurrent requests must not stampede the recovery probe");
+
+    resolveRecovery(jsonResponse({ jsonrpc: "2.0", id: 1, result: "recovered" }));
+    assert.equal(await firstRecovery, "recovered");
+
+    const healthState = (manager as any).rpcHealthStates.get(rpc);
+    assert.equal(healthState.consecutiveFailures, 0);
+    assert.equal(healthState.lastFailureTime, 0);
+    assert.equal(healthState.recoveryProbeInFlight, false);
+
+    phase = "healthy";
+    assert.equal(await manager.send(1, "eth_blockNumber", ["after-recovery"]), "healthy");
+    assert.equal(calls.length, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(Date, "now", originalNowDescriptor);
+    restoreOpenKv();
+  }
+});
+
+Deno.test("health, logs, and exhausted errors use opaque endpoint diagnostics", async () => {
+  const secretRpc = "https://user:super-secret@provider.example/private-path?token=super-token";
+  const manager = createManager([secretRpc], { logLevel: "debug" });
+  const restoreOpenKv = installOpenKvMock();
+  const originalFetch = globalThis.fetch;
+  const originalConsole = new Map<string, (...args: unknown[]) => void>();
+  const diagnostics: unknown[][] = [];
+  const levels = ["debug", "info", "warn", "error"];
+
+  for (const level of levels) {
+    const logger = (console as unknown as Record<string, (...args: unknown[]) => void>)[level];
+    originalConsole.set(level, logger);
+    (console as unknown as Record<string, (...args: unknown[]) => void>)[level] = (...args) => diagnostics.push(args);
+  }
+
+  globalThis.fetch = (() => Promise.reject(new Error(`upstream failed at ${secretRpc}`))) as typeof fetch;
+
+  try {
+    let error: unknown;
+    try {
+      await manager.send(1, "eth_blockNumber");
+    } catch (caught) {
+      error = caught;
+    }
+    assert.ok(error instanceof Error);
+    const serializedError = JSON.stringify({ message: error.message, data: (error as { data?: unknown }).data });
+    const health = JSON.stringify(await manager.getHealthStatus());
+    const logged = JSON.stringify(diagnostics);
+
+    for (const diagnostic of [serializedError, health, logged]) {
+      assert.equal(diagnostic.includes("super-secret"), false);
+      assert.equal(diagnostic.includes("super-token"), false);
+      assert.equal(diagnostic.includes("provider.example"), false);
+      assert.equal(diagnostic.includes("private-path"), false);
+    }
+
+    assert.match(serializedError, new RegExp(getRpcEndpointId(secretRpc)));
+    assert.match(health, new RegExp(getRpcEndpointId(secretRpc)));
+    assert.match(logged, new RegExp(getRpcEndpointId(secretRpc)));
+  } finally {
+    globalThis.fetch = originalFetch;
+    for (const [level, logger] of originalConsole) {
+      (console as unknown as Record<string, (...args: unknown[]) => void>)[level] = logger;
+    }
+    restoreOpenKv();
+  }
+});

--- a/packages/permit2-rpc-server/src/core/permit2-rpc-manager_override_test.ts
+++ b/packages/permit2-rpc-server/src/core/permit2-rpc-manager_override_test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { getRpcEndpointId } from "./rpc-endpoint-id.ts";
 import { Permit2RpcManager } from "./permit2-rpc-manager.ts";
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
@@ -22,17 +23,19 @@ Deno.test("Overrides: tries override then fallback when allowed", async () => {
     configurable: originalOpenKvDescriptor.configurable,
     enumerable: originalOpenKvDescriptor.enumerable,
     writable: true,
-    value: (async () =>
-      ({
+    value: (() =>
+      Promise.resolve({
         set: async () => {},
+        delete: async () => {},
         close: () => {},
-      }) as unknown as Deno.Kv) as typeof Deno.openKv,
+      } as unknown as Deno.Kv)) as typeof Deno.openKv,
   });
 
   const manager = new Permit2RpcManager({
     initialRpcData: { rpcs: { [String(chainId)]: [overrideRpc, fallbackRpc] } },
     disableCache: true,
     logLevel: "none",
+    scoringV2: { enabled: false },
   });
 
   manager.rpcSelector.getRankedRpcList = () => Promise.resolve([overrideRpc, fallbackRpc]);
@@ -68,6 +71,7 @@ Deno.test("Overrides: tries override then fallback when allowed", async () => {
 Deno.test("Overrides: invalid params when no override matches and fallback disabled", async () => {
   const chainId = 1;
   const rpc1 = "https://rpc1.example";
+  const unavailableOverride = "https://user:secret@override.example/private?token=secret-token";
 
   const manager = new Permit2RpcManager({
     initialRpcData: { rpcs: { [String(chainId)]: [rpc1] } },
@@ -77,16 +81,111 @@ Deno.test("Overrides: invalid params when no override matches and fallback disab
 
   manager.rpcSelector.getRankedRpcList = () => Promise.resolve([rpc1]);
 
-  await assert.rejects(
-    () =>
-      manager.send(chainId, "eth_blockNumber", [], {
-        rpcOverrides: ["https://not-in-whitelist.example"],
-        allowFallback: false,
-      }),
-    (err) => {
-      if (!err || typeof err !== "object") return false;
-      if (!("code" in err)) return false;
-      return (err as { code: number }).code === -32602;
-    }
-  );
+  let error: unknown;
+  try {
+    await manager.send(chainId, "eth_blockNumber", [], {
+      rpcOverrides: [unavailableOverride],
+      allowFallback: false,
+    });
+  } catch (caught) {
+    error = caught;
+  }
+
+  assert.ok(error && typeof error === "object" && "code" in error);
+  assert.equal((error as { code: number }).code, -32602);
+  const serialized = JSON.stringify(error);
+  assert.equal(serialized.includes("override.example"), false);
+  assert.equal(serialized.includes("secret-token"), false);
+  assert.match(serialized, new RegExp(getRpcEndpointId(unavailableOverride)));
+});
+
+Deno.test("Overrides: sequential execution keeps an override ahead of a higher-ranked fallback", async () => {
+  const chainId = 1;
+  const overrideRpc = "https://override.example";
+  const fallbackRpc = "https://fallback.example";
+  const manager = new Permit2RpcManager({
+    initialRpcData: { rpcs: { [String(chainId)]: [fallbackRpc, overrideRpc] } },
+    disableCache: true,
+    logLevel: "none",
+    scoringV2: { enabled: false },
+  });
+  manager.rpcSelector.getRankedRpcList = () => Promise.resolve([fallbackRpc, overrideRpc]);
+  (manager as any).rpcScorer.getRankedRpcs = (rpcs: string[]) => rpcs;
+
+  const originalOpenKvDescriptor = Object.getOwnPropertyDescriptor(Deno, "openKv");
+  if (!originalOpenKvDescriptor) throw new Error("Deno.openKv descriptor is unavailable");
+  Object.defineProperty(Deno, "openKv", {
+    configurable: originalOpenKvDescriptor.configurable,
+    enumerable: originalOpenKvDescriptor.enumerable,
+    writable: true,
+    value: (() =>
+      Promise.resolve(
+        { set: async () => {}, delete: async () => {}, close: () => {} } as unknown as Deno.Kv,
+      )) as typeof Deno.openKv,
+  });
+
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = ((input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    calls.push(url);
+    if (url === overrideRpc) return Promise.reject(new Error("override down"));
+    return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "fallback-result" }));
+  }) as typeof fetch;
+
+  try {
+    assert.equal(
+      await manager.send(chainId, "eth_blockNumber", [], { rpcOverrides: [overrideRpc], allowFallback: true }),
+      "fallback-result",
+    );
+    assert.deepEqual(calls, [overrideRpc, fallbackRpc]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(Deno, "openKv", originalOpenKvDescriptor);
+  }
+});
+
+Deno.test("Overrides: disabled fallback never attempts a non-override RPC", async () => {
+  const chainId = 1;
+  const overrideRpc = "https://override.example";
+  const fallbackRpc = "https://fallback.example";
+  const manager = new Permit2RpcManager({
+    initialRpcData: { rpcs: { [String(chainId)]: [fallbackRpc, overrideRpc] } },
+    disableCache: true,
+    logLevel: "none",
+    scoringV2: { enabled: false },
+  });
+  manager.rpcSelector.getRankedRpcList = () => Promise.resolve([fallbackRpc, overrideRpc]);
+  (manager as any).rpcScorer.getRankedRpcs = (rpcs: string[]) => rpcs;
+
+  const originalOpenKvDescriptor = Object.getOwnPropertyDescriptor(Deno, "openKv");
+  if (!originalOpenKvDescriptor) throw new Error("Deno.openKv descriptor is unavailable");
+  Object.defineProperty(Deno, "openKv", {
+    configurable: originalOpenKvDescriptor.configurable,
+    enumerable: originalOpenKvDescriptor.enumerable,
+    writable: true,
+    value: (() =>
+      Promise.resolve(
+        { set: async () => {}, delete: async () => {}, close: () => {} } as unknown as Deno.Kv,
+      )) as typeof Deno.openKv,
+  });
+
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = ((input) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    calls.push(url);
+    if (url === overrideRpc) return Promise.reject(new Error("override down"));
+    return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "unexpected fallback" }));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(() =>
+      manager.send(chainId, "eth_blockNumber", [], { rpcOverrides: [overrideRpc], allowFallback: false })
+    );
+    assert.deepEqual(calls, [overrideRpc]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(Deno, "openKv", originalOpenKvDescriptor);
+  }
 });

--- a/packages/permit2-rpc-server/src/core/rpc-endpoint-id.test.ts
+++ b/packages/permit2-rpc-server/src/core/rpc-endpoint-id.test.ts
@@ -1,0 +1,17 @@
+import { assertEquals, assertMatch } from "jsr:@std/assert@1";
+import { getRpcEndpointId, redactRpcDiagnostic } from "./rpc-endpoint-id.ts";
+
+Deno.test("RPC endpoint diagnostics are stable and redact nested URL values", () => {
+  const endpoint = "https://user:secret@rpc.example/private?token=token-value";
+  const endpointId = getRpcEndpointId(endpoint);
+  const diagnostic = redactRpcDiagnostic({
+    message: `failed ${endpoint}`,
+    nested: [endpoint, { url: endpoint }],
+  });
+
+  assertEquals(getRpcEndpointId(endpoint), endpointId);
+  assertMatch(endpointId, /^rpc-[0-9a-f]{16}$/);
+  assertEquals(JSON.stringify(diagnostic).includes("secret"), false);
+  assertEquals(JSON.stringify(diagnostic).includes("rpc.example"), false);
+  assertEquals(JSON.stringify(diagnostic).includes(endpointId), true);
+});

--- a/packages/permit2-rpc-server/src/core/rpc-endpoint-id.ts
+++ b/packages/permit2-rpc-server/src/core/rpc-endpoint-id.ts
@@ -1,0 +1,51 @@
+const FNV_64_OFFSET_BASIS = 0xcbf29ce484222325n;
+const FNV_64_PRIME = 0x100000001b3n;
+const FNV_64_MASK = 0xffffffffffffffffn;
+const RPC_URL_PATTERN = /\b(?:https?|wss?):\/\/[^\s\]\[<>"'`),;]+/gi;
+
+function normalizeEndpoint(value: string): string {
+  return value.trim().replace(/\/$/, "");
+}
+
+/**
+ * Produces a stable diagnostic identifier without exposing an upstream URL.
+ */
+export function getRpcEndpointId(url: string): string {
+  const normalized = normalizeEndpoint(url);
+  let hash = FNV_64_OFFSET_BASIS;
+
+  for (let index = 0; index < normalized.length; index++) {
+    hash ^= BigInt(normalized.charCodeAt(index));
+    hash = (hash * FNV_64_PRIME) & FNV_64_MASK;
+  }
+
+  return `rpc-${hash.toString(16).padStart(16, "0")}`;
+}
+
+export function redactRpcDiagnostic(value: string): string;
+export function redactRpcDiagnostic<T>(value: T): T;
+/**
+ * Replaces URL-shaped values in diagnostic payloads while retaining their shape.
+ */
+export function redactRpcDiagnostic(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value.replace(RPC_URL_PATTERN, (url) => getRpcEndpointId(url));
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: redactRpcDiagnostic(value.message),
+    };
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactRpcDiagnostic(entry));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, redactRpcDiagnostic(entry)]));
+  }
+
+  return value;
+}

--- a/packages/permit2-rpc-server/src/core/rpc-selector.ts
+++ b/packages/permit2-rpc-server/src/core/rpc-selector.ts
@@ -1,5 +1,6 @@
 import { CacheManager } from "../infra/cache-manager.ts";
 import { LatencyTestResult } from "../infra/latency-tester.ts";
+import { getRpcEndpointId, redactRpcDiagnostic } from "./rpc-endpoint-id.ts";
 
 // Define a logger type
 type LoggerFn = (
@@ -26,7 +27,12 @@ export class RpcSelector {
   private log: LoggerFn;
   private ongoingLatencyTests = new Map<number, Promise<Record<string, LatencyTestResult>>>();
 
-  constructor(dataSource: RpcDataSourceLike, cacheManager: CacheManager, latencyTester: LatencyTesterLike, logger?: LoggerFn) {
+  constructor(
+    dataSource: RpcDataSourceLike,
+    cacheManager: CacheManager,
+    latencyTester: LatencyTesterLike,
+    logger?: LoggerFn,
+  ) {
     this.dataSource = dataSource;
     this.cacheManager = cacheManager;
     this.latencyTester = latencyTester;
@@ -66,7 +72,12 @@ export class RpcSelector {
       !ACCEPTABLE_STATUSES.includes(latencyMap[fastestCachedRpc].status)
     ) {
       if (fastestCachedRpc && latencyMap) {
-        this.log("info", `Cached fastest RPC ${fastestCachedRpc} for chain ${chainId} is no longer valid or missing in map. Re-testing.`);
+        this.log(
+          "info",
+          `Cached fastest RPC ${
+            getRpcEndpointId(fastestCachedRpc)
+          } for chain ${chainId} is no longer valid or missing in map. Re-testing.`,
+        );
       } else {
         this.log("info", `No valid cache for chain ${chainId}. Performing latency tests...`);
       }
@@ -88,12 +99,22 @@ export class RpcSelector {
           const newFastest = this._findFastestInMap(latencyMap);
           await this.cacheManager.updateChainCache(chainId, latencyMap, newFastest?.url ?? null);
           if (newFastest) {
-            this.log("info", `Selected fastest RPC for chain ${chainId}: ${newFastest.url} (${newFastest.latency}ms, status: ${newFastest.status})`);
+            this.log(
+              "info",
+              `Selected fastest RPC for chain ${chainId}: ${
+                getRpcEndpointId(newFastest.url)
+              } (${newFastest.latency}ms, status: ${newFastest.status})`,
+            );
           } else {
-            this.log("warn", `No responsive RPCs found meeting criteria (${ACCEPTABLE_STATUSES.join(" > ")}) for chain ${chainId} after testing.`);
+            this.log(
+              "warn",
+              `No responsive RPCs found meeting criteria (${
+                ACCEPTABLE_STATUSES.join(" > ")
+              }) for chain ${chainId} after testing.`,
+            );
           }
         } catch (error) {
-          this.log("error", `Latency test failed for chain ${chainId}`, error);
+          this.log("error", `Latency test failed for chain ${chainId}`, redactRpcDiagnostic(error));
           latencyMap = {}; // Set empty map on error
         } finally {
           this.ongoingLatencyTests.delete(chainId); // Remove promise once done
@@ -107,7 +128,7 @@ export class RpcSelector {
 
     // Filter and sort the results from the (potentially updated) latency map
     const rankedList = this._rankResults(latencyMap, allowedUrls);
-    this.log("debug", `Ranked RPC list for chain ${chainId}:`, rankedList);
+    this.log("debug", `Ranked RPC list for chain ${chainId}:`, redactRpcDiagnostic(rankedList));
     return rankedList;
   }
 
@@ -163,11 +184,11 @@ export class RpcSelector {
       if (invalidated && healthStatus === "eliminated") {
         // Check if it's time to retry
         if (nextRetryAt && Date.now() >= nextRetryAt) {
-          this.log("debug", `RPC ${result.url} eligible for retry after elimination period`);
+          this.log("debug", `RPC ${getRpcEndpointId(result.url)} eligible for retry after elimination period`);
           // Allow retry by including it
           return true;
         }
-        this.log("debug", `Excluding eliminated RPC: ${result.url}`);
+        this.log("debug", `Excluding eliminated RPC: ${getRpcEndpointId(result.url)}`);
         return false;
       }
 

--- a/packages/permit2-rpc-server/src/core/rpc-selector_test.ts
+++ b/packages/permit2-rpc-server/src/core/rpc-selector_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "jsr:@std/assert@1";
 import { CacheManager } from "../infra/cache-manager.ts";
 import type { LatencyTestResult } from "../infra/latency-tester.ts";
+import { getRpcEndpointId } from "./rpc-endpoint-id.ts";
 import { RpcSelector } from "./rpc-selector.ts";
 
 class MemoryCacheManager extends CacheManager {
@@ -18,7 +19,11 @@ class MemoryCacheManager extends CacheManager {
     return this.store.get(chainId)?.latencyMap ?? null;
   }
 
-  override async updateChainCache(chainId: number, latencyMap: Record<string, LatencyTestResult>, fastestRpc: string | null): Promise<void> {
+  override async updateChainCache(
+    chainId: number,
+    latencyMap: Record<string, LatencyTestResult>,
+    fastestRpc: string | null,
+  ): Promise<void> {
     this.store.set(chainId, { fastestRpc, latencyMap });
   }
 }
@@ -86,4 +91,44 @@ Deno.test("RpcSelector: ignores cached fastest RPC not in data source", async ()
   const ranked = await selector.getRankedRpcList(chainId);
 
   assertEquals(ranked, [okRpc]);
+});
+
+Deno.test("RpcSelector: redacts RPC URLs from selector diagnostics", async () => {
+  const chainId = 1;
+  const rpcUrl = "https://user:super-secret@rpc.example/rpc?apiKey=very-secret";
+  const diagnostics: unknown[][] = [];
+  const dataSource = { getRpcUrls: () => [rpcUrl] };
+  const cacheManager = new CacheManager({ disableCache: true });
+  const latencyTester = {
+    testRpcUrls: (): Promise<Record<string, LatencyTestResult>> =>
+      Promise.resolve({ [rpcUrl]: { url: rpcUrl, latency: 10, status: "ok" } }),
+  };
+
+  const selector = new RpcSelector(dataSource, cacheManager, latencyTester, (...args) => diagnostics.push(args));
+  await selector.getRankedRpcList(chainId);
+
+  const logged = JSON.stringify(diagnostics);
+  assertEquals(logged.includes(rpcUrl), false);
+  assertEquals(logged.includes("super-secret"), false);
+  assertEquals(logged.includes(getRpcEndpointId(rpcUrl)), true);
+});
+
+Deno.test("RpcSelector: redacts URLs in latency-test errors", async () => {
+  const chainId = 1;
+  const rpcUrl = "https://user:super-secret@rpc.example/rpc?apiKey=very-secret";
+  const diagnostics: unknown[][] = [];
+  const dataSource = { getRpcUrls: () => [rpcUrl] };
+  const cacheManager = new CacheManager({ disableCache: true });
+  const latencyTester = {
+    testRpcUrls: (): Promise<Record<string, LatencyTestResult>> =>
+      Promise.reject(new Error(`Latency probe failed for ${rpcUrl}`)),
+  };
+
+  const selector = new RpcSelector(dataSource, cacheManager, latencyTester, (...args) => diagnostics.push(args));
+  await selector.getRankedRpcList(chainId);
+
+  const logged = JSON.stringify(diagnostics);
+  assertEquals(logged.includes(rpcUrl), false);
+  assertEquals(logged.includes("super-secret"), false);
+  assertEquals(logged.includes(getRpcEndpointId(rpcUrl)), true);
 });

--- a/packages/permit2-rpc-server/src/deno-server.ts
+++ b/packages/permit2-rpc-server/src/deno-server.ts
@@ -9,8 +9,11 @@ import { RpcSelector } from "./core/rpc-selector.ts";
 import { ChainlistWsDataSource } from "./data/chainlist-ws-data-source.ts";
 import { WsLatencyTester } from "./infra/ws-latency-tester.ts";
 import { handleMcpRequest, isMcpRequest } from "./mcp/handler.ts";
+import { getRpcEndpointId, redactRpcDiagnostic } from "./core/rpc-endpoint-id.ts";
 // Adjust path to point one level up from src/
 import rpcWhitelist from "../rpc-whitelist.json" with { type: "json" };
+
+export type RequestHandlerManager = Pick<Permit2RpcManager, "getHealthStatus" | "multicall3" | "send">;
 
 // Type guard to check for valid JSON-RPC request object structure
 function isValidJsonRpcRequest(obj: unknown): obj is JsonRpcRequest {
@@ -109,13 +112,19 @@ function parseLogLevelEnv(name: string): Permit2RpcManagerOptions["logLevel"] | 
   const raw = Deno.env.get(name);
   if (!raw) return undefined;
   const normalized = raw.trim().toLowerCase();
-  if (normalized === "debug" || normalized === "info" || normalized === "warn" || normalized === "error" || normalized === "none") {
+  if (
+    normalized === "debug" || normalized === "info" || normalized === "warn" || normalized === "error" ||
+    normalized === "none"
+  ) {
     return normalized as Permit2RpcManagerOptions["logLevel"];
   }
   return undefined;
 }
 
-function buildPermit2RpcManagerOptionsFromEnv(initialRpcData: Permit2RpcManagerOptions["initialRpcData"], disableCache: boolean): Permit2RpcManagerOptions {
+function buildPermit2RpcManagerOptionsFromEnv(
+  initialRpcData: Permit2RpcManagerOptions["initialRpcData"],
+  disableCache: boolean,
+): Permit2RpcManagerOptions {
   const scoringV2: NonNullable<Permit2RpcManagerOptions["scoringV2"]> = {};
   const scoringV2Enabled = parseBoolEnv("RPC_SCORING_V2_ENABLED");
   if (scoringV2Enabled !== undefined) scoringV2.enabled = scoringV2Enabled;
@@ -195,7 +204,10 @@ type WsLogLevel = "debug" | "info" | "warn" | "error";
 const wsLogger = (level: WsLogLevel, message: string, ...optionalParams: unknown[]) => {
   if (level === "debug" || level === "info") return;
   const logFn = console[level] || console.log;
-  logFn(`[Permit2WSS:${level}] ${message}`, ...optionalParams);
+  logFn(
+    `[Permit2WSS:${level}] ${redactRpcDiagnostic(message)}`,
+    ...optionalParams.map((optionalParam) => redactRpcDiagnostic(optionalParam)),
+  );
 };
 
 const wsCandidateLimitRaw = Number.parseInt(Deno.env.get("WS_CANDIDATE_LIMIT") ?? "25", 10);
@@ -207,7 +219,9 @@ const wsCacheManager = new CacheManager({
   disableCache: shouldDisableCache,
 });
 const wsLatencyTesterTimeoutMsRaw = Number.parseInt(Deno.env.get("WS_LATENCY_TIMEOUT_MS") ?? "5000", 10);
-const wsLatencyTesterTimeoutMs = Number.isFinite(wsLatencyTesterTimeoutMsRaw) && wsLatencyTesterTimeoutMsRaw > 0 ? wsLatencyTesterTimeoutMsRaw : 5000;
+const wsLatencyTesterTimeoutMs = Number.isFinite(wsLatencyTesterTimeoutMsRaw) && wsLatencyTesterTimeoutMsRaw > 0
+  ? wsLatencyTesterTimeoutMsRaw
+  : 5000;
 const wsLatencyTester = new WsLatencyTester(wsLatencyTesterTimeoutMs, wsLogger);
 const wsSelector = new RpcSelector(wsDataSource, wsCacheManager, wsLatencyTester, wsLogger);
 
@@ -329,12 +343,21 @@ function isNotFoundError(error: unknown): boolean {
   return error instanceof Deno.errors.NotFound;
 }
 
-const handler = async (request: Request): Promise<Response> => {
+/**
+ * Creates the HTTP request handler without starting a listener. Keeping the
+ * manager injectable makes the JSON-RPC request path directly testable.
+ */
+export function createHandler(manager: RequestHandlerManager): (request: Request) => Promise<Response> {
+  return (request) => handleRequest(request, manager);
+}
+
+async function handleRequest(request: Request, manager: RequestHandlerManager): Promise<Response> {
   // Set CORS headers for all responses
   const corsHeaders = {
     "Access-Control-Allow-Origin": "*", // Allow requests from any origin
     "Access-Control-Allow-Methods": "GET, HEAD, POST, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type, Authorization, X-UBQ-RPC-CANDIDATES, X-UBQ-RPC-URL, X-UBQ-RPC-FALLBACK",
+    "Access-Control-Allow-Headers":
+      "Content-Type, Authorization, X-UBQ-RPC-CANDIDATES, X-UBQ-RPC-URL, X-UBQ-RPC-FALLBACK",
   };
 
   // WebSocket JSON-RPC proxy (ws/wss). Connect clients to our server, proxy to an upstream WS RPC.
@@ -400,7 +423,9 @@ const handler = async (request: Request): Promise<Response> => {
             queuedToUpstream.push(payload);
           } else if (!clientClosed) {
             clientClosed = true;
-            console.warn(`WebSocket upstream queue overflow (limit: ${MAX_QUEUE}) for chainId ${chainId}. Closing client connection.`);
+            console.warn(
+              `WebSocket upstream queue overflow (limit: ${MAX_QUEUE}) for chainId ${chainId}. Closing client connection.`,
+            );
             try {
               socket.close(4000, "Upstream queue overflow");
             } catch {
@@ -456,7 +481,9 @@ const handler = async (request: Request): Promise<Response> => {
         try {
           upstream = await connectFirstWebSocket(overrideCandidates, connectTimeout);
         } catch (error) {
-          const message = error instanceof Error ? error.message : "Failed to connect to configured WS override";
+          const message = error instanceof Error
+            ? redactRpcDiagnostic(error.message)
+            : "Failed to connect to configured WS override";
           wsLogger("warn", `WS override failed for chain ${chainId}: ${message}`);
         }
       }
@@ -488,7 +515,7 @@ const handler = async (request: Request): Promise<Response> => {
         }
 
         if (!upstream) {
-          const message = lastError?.message ?? "Failed to connect to upstream WebSocket";
+          const message = redactRpcDiagnostic(lastError?.message ?? "Failed to connect to upstream WebSocket");
           try {
             socket.close(1011, message);
           } catch {
@@ -551,7 +578,7 @@ const handler = async (request: Request): Promise<Response> => {
         },
       });
     } catch (error) {
-      console.error("Failed to read static asset logo.svg:", error);
+      console.error("Failed to read static asset logo.svg:", redactRpcDiagnostic(error));
       return new Response("Not Found", {
         status: isNotFoundError(error) ? 404 : 500,
         headers: corsHeaders,
@@ -571,7 +598,7 @@ const handler = async (request: Request): Promise<Response> => {
         },
       });
     } catch (error) {
-      console.error("Failed to read static asset app.css:", error);
+      console.error("Failed to read static asset app.css:", redactRpcDiagnostic(error));
       return new Response("Not Found", {
         status: isNotFoundError(error) ? 404 : 500,
         headers: corsHeaders,
@@ -591,7 +618,7 @@ const handler = async (request: Request): Promise<Response> => {
         },
       });
     } catch (error) {
-      console.error("Failed to read static asset app.js:", error);
+      console.error("Failed to read static asset app.js:", redactRpcDiagnostic(error));
       return new Response("Not Found", {
         status: isNotFoundError(error) ? 404 : 500,
         headers: corsHeaders,
@@ -616,7 +643,7 @@ const handler = async (request: Request): Promise<Response> => {
       return new Response(
         JSON.stringify({
           error: "Failed to retrieve health status",
-          message: error instanceof Error ? error.message : String(error),
+          message: redactRpcDiagnostic(error instanceof Error ? error.message : String(error)),
         }),
         {
           status: 500,
@@ -624,7 +651,7 @@ const handler = async (request: Request): Promise<Response> => {
             "content-type": "application/json; charset=utf-8",
             ...corsHeaders,
           },
-        }
+        },
       );
     }
   }
@@ -641,7 +668,7 @@ const handler = async (request: Request): Promise<Response> => {
         },
       });
     } catch (error) {
-      console.error("Failed to read static asset index.html:", error);
+      console.error("Failed to read static asset index.html:", redactRpcDiagnostic(error));
       return new Response("Not Found", {
         status: isNotFoundError(error) ? 404 : 500,
         headers: corsHeaders,
@@ -678,9 +705,9 @@ const handler = async (request: Request): Promise<Response> => {
     requestBody = await request.json();
   } catch (e) {
     const error = e instanceof Error ? e : new Error(String(e));
-    console.error("Failed to parse request body:", error);
+    console.error("Failed to parse request body:", redactRpcDiagnostic(error));
     // Return JSON-RPC error for parse error
-    const errorResponse = createJsonRpcError(null, -32700, `Parse error: ${error.message}`);
+    const errorResponse = createJsonRpcError(null, -32700, `Parse error: ${redactRpcDiagnostic(error.message)}`);
     return new Response(JSON.stringify(errorResponse), {
       status: 200, // JSON-RPC compliance: parse errors return HTTP 200
       headers: { ...corsHeaders, "Content-Type": "application/json" },
@@ -689,7 +716,7 @@ const handler = async (request: Request): Promise<Response> => {
 
   // Check if this is an MCP request (at root path or with chainId)
   if (isMcpRequest(requestBody)) {
-    return handleMcpRequest({ requestBody, pathParts, manager, corsHeaders });
+    return handleMcpRequest({ requestBody, pathParts, manager: manager as Permit2RpcManager, corsHeaders });
   }
 
   // For regular JSON-RPC requests, require chainId in path
@@ -714,7 +741,10 @@ const handler = async (request: Request): Promise<Response> => {
   const overrideOptions = parseRpcOverrideOptions(request.headers);
   if (overrideOptions) {
     console.log(
-      `Received RPC override headers for chain ${chainId}: ` + `${overrideOptions.rpcOverrides.join(", ")} (allowFallback=${overrideOptions.allowFallback})`
+      `Received RPC override headers for chain ${chainId}: ` +
+        `${
+          overrideOptions.rpcOverrides.map(getRpcEndpointId).join(", ")
+        } (allowFallback=${overrideOptions.allowFallback})`,
     );
   }
 
@@ -732,7 +762,11 @@ const handler = async (request: Request): Promise<Response> => {
 
     // Validate all requests in the batch first
     if (!requestBody.every(isValidJsonRpcRequest)) {
-      const errorResponse = createJsonRpcError(null, -32600, "Invalid Request: Batch contains invalid JSON-RPC object(s).");
+      const errorResponse = createJsonRpcError(
+        null,
+        -32600,
+        "Invalid Request: Batch contains invalid JSON-RPC object(s).",
+      );
       return new Response(JSON.stringify(errorResponse), {
         status: 200, // JSON-RPC compliance: invalid requests return HTTP 200
         headers: { ...corsHeaders, "Content-Type": "application/json" },
@@ -740,7 +774,9 @@ const handler = async (request: Request): Promise<Response> => {
     }
 
     const multiCallRequests = requestBody.filter((req) => isMulticall3Request(chainId, req));
-    const otherRequests = requestBody.filter((req) => req.id && !multiCallRequests.map((r) => r.id).includes(req.id));
+    const otherRequests = requestBody.filter((req) =>
+      req.id !== null && !multiCallRequests.map((r) => r.id).includes(req.id)
+    );
 
     // group by block tag and split the array into chunks of 500 to avoid exceeding multicall limits
     const multiCallRequestsByBlockTag = multiCallRequests.reduce(
@@ -757,7 +793,7 @@ const handler = async (request: Request): Promise<Response> => {
         }
         return acc;
       },
-      {} as Record<string, Multicall3Request[][]>
+      {} as Record<string, Multicall3Request[][]>,
     );
 
     const multicallPromises: Promise<JsonRpcResponse[]>[] = [];
@@ -778,23 +814,28 @@ const handler = async (request: Request): Promise<Response> => {
           return { jsonrpc: "2.0", id: req.id, result } as JsonRpcResponse;
         } catch (e) {
           const error = e instanceof Error ? e : new Error(String(e));
-          console.error(`Error processing batch item (id: ${req.id}, method: ${req.method}) for chain ${chainId}:`, error);
+          console.error(
+            `Error processing batch item (id: ${req.id}, method: ${req.method}) for chain ${chainId}:`,
+            redactRpcDiagnostic(error),
+          );
 
           // Extract error details consistently
-          const code = error.name === "JsonRpcError" && "code" in error && typeof error.code === "number" ? error.code : -32603;
-          const data = "data" in error ? error.data : undefined;
+          const code = error.name === "JsonRpcError" && "code" in error && typeof error.code === "number"
+            ? error.code
+            : -32603;
+          const data = "data" in error ? redactRpcDiagnostic(error.data) : undefined;
 
           return {
             jsonrpc: "2.0",
             id: req.id,
             error: {
               code,
-              message: error.message,
+              message: redactRpcDiagnostic(error.message),
               data,
             },
           } as JsonRpcResponse;
         }
-      })
+      }),
     );
 
     return new Response(JSON.stringify([...multicallResponses, ...otherResponses]), {
@@ -819,7 +860,10 @@ const handler = async (request: Request): Promise<Response> => {
       });
     } catch (e) {
       const error = e instanceof Error ? e : new Error(String(e));
-      console.error(`Error processing single request (id: ${requestBody.id}, method: ${requestBody.method}) for chain ${chainId}:`, error);
+      console.error(
+        `Error processing single request (id: ${requestBody.id}, method: ${requestBody.method}) for chain ${chainId}:`,
+        redactRpcDiagnostic(error),
+      );
 
       // Pass through HTTP status if available, otherwise default to 200 for JSON-RPC compliance
       // Contract reverts and JSON-RPC errors should return HTTP 200 per JSON-RPC spec
@@ -833,8 +877,8 @@ const handler = async (request: Request): Promise<Response> => {
         id: requestBody.id,
         error: {
           code: "code" in error && typeof error.code === "number" ? error.code : -32603,
-          message: error.message,
-          data: "data" in error ? error.data : undefined,
+          message: redactRpcDiagnostic(error.message),
+          data: "data" in error ? redactRpcDiagnostic(error.data) : undefined,
         },
       };
 
@@ -845,14 +889,16 @@ const handler = async (request: Request): Promise<Response> => {
     }
   } // --- Handle Invalid Request Structure ---
   else {
-    console.error("Invalid request body structure:", requestBody);
+    console.error("Invalid request body structure:", redactRpcDiagnostic(requestBody));
     const errorResponse = createJsonRpcError(null, -32600, "Invalid Request: Not a valid JSON-RPC object or batch.");
     return new Response(JSON.stringify(errorResponse), {
       status: 200, // JSON-RPC compliance: invalid requests return HTTP 200
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   }
-};
+}
 
-console.log(`Permit2 RPC Manager Proxy listening on http://localhost:${PORT}`);
-Deno.serve({ port: PORT }, handler);
+if (import.meta.main) {
+  console.log(`Permit2 RPC Manager Proxy listening on http://localhost:${PORT}`);
+  Deno.serve({ port: PORT }, createHandler(manager));
+}

--- a/packages/permit2-rpc-server/src/deno-server_batch.test.ts
+++ b/packages/permit2-rpc-server/src/deno-server_batch.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { createHandler, type RequestHandlerManager } from "./deno-server.ts";
+
+Deno.test("HTTP batch responses preserve ordinary JSON-RPC ID 0", async () => {
+  const calls: Array<{ chainId: number; method: string; params: unknown[] }> = [];
+  const manager: RequestHandlerManager = {
+    getHealthStatus: () => Promise.resolve({}),
+    multicall3: () => Promise.resolve([]),
+    send: <T = unknown>(chainId: number, method: string, params: unknown[] = []): Promise<T> => {
+      calls.push({ chainId, method, params });
+      return Promise.resolve({ method } as T);
+    },
+  };
+  const handler = createHandler(manager);
+
+  const response = await handler(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([
+        { jsonrpc: "2.0", id: 0, method: "eth_chainId", params: [] },
+        { jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: [] },
+      ]),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const responses = await response.json();
+  assert.ok(Array.isArray(responses));
+  assert.deepEqual(
+    responses.map((item) => item.id),
+    [0, 1],
+  );
+  assert.deepEqual(responses, [
+    { jsonrpc: "2.0", id: 0, result: { method: "eth_chainId" } },
+    { jsonrpc: "2.0", id: 1, result: { method: "eth_blockNumber" } },
+  ]);
+  assert.deepEqual(calls, [
+    { chainId: 1, method: "eth_chainId", params: [] },
+    { chainId: 1, method: "eth_blockNumber", params: [] },
+  ]);
+});
+
+Deno.test("HTTP errors redact upstream credentials from message and data", async () => {
+  const upstreamUrl = "https://rpc-user:rpc-password@rpc.example.test/v1?token=secret-query-token";
+  const upstreamError = Object.assign(new Error(`Upstream request failed: ${upstreamUrl}`), {
+    data: { endpoint: upstreamUrl },
+  });
+  const manager: RequestHandlerManager = {
+    getHealthStatus: () => Promise.resolve({}),
+    multicall3: () => Promise.resolve([]),
+    send: <T = unknown>(): Promise<T> => Promise.reject(upstreamError),
+  };
+
+  const response = await createHandler(manager)(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: [] }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const serializedBody = await response.text();
+  assert.doesNotMatch(serializedBody, /rpc\.example\.test/);
+  assert.doesNotMatch(serializedBody, /rpc-user:rpc-password/);
+  assert.doesNotMatch(serializedBody, /secret-query-token/);
+  assert.match(serializedBody, /rpc-[0-9a-f]{16}/);
+});

--- a/packages/permit2-rpc-server/src/evm/multicall3_test.ts
+++ b/packages/permit2-rpc-server/src/evm/multicall3_test.ts
@@ -39,10 +39,17 @@ Deno.test("isMulticall3Request: rejects eth_call with value set", () => {
   assertEquals(isMulticall3Request(chainId, withValue as JsonRpcRequest), false);
 });
 
-Deno.test("isMulticall3Request: rejects sender-sensitive selectors", () => {
-  const permitCall = {
-    ...baseRequest,
-    params: [{ ...baseCall, data: "0x30f28b7a00" }, "latest"],
-  } satisfies JsonRpcRequest;
-  assertEquals(isMulticall3Request(chainId, permitCall as JsonRpcRequest), false);
+Deno.test("isMulticall3Request: accepts ID 0", () => {
+  const idZeroRequest = { ...baseRequest, id: 0 } satisfies JsonRpcRequest;
+  assertEquals(isMulticall3Request(chainId, idZeroRequest), true);
+});
+
+Deno.test("isMulticall3Request: rejects every sender-sensitive Permit2 selector", () => {
+  for (const selector of ["0x30f28b7a", "0x6700a7c5", "0x32d88955", "0xbba8c6d5"]) {
+    const permitCall = {
+      ...baseRequest,
+      params: [{ ...baseCall, data: `${selector}00` }, "latest"],
+    } satisfies JsonRpcRequest;
+    assertEquals(isMulticall3Request(chainId, permitCall as JsonRpcRequest), false, selector);
+  }
 });

--- a/packages/permit2-rpc-server/src/infra/cache-manager.ts
+++ b/packages/permit2-rpc-server/src/infra/cache-manager.ts
@@ -1,4 +1,5 @@
 /// <reference lib="deno.ns" />
+import { getRpcEndpointId, redactRpcDiagnostic } from "../core/rpc-endpoint-id.ts";
 import type { LatencyTestResult } from "./latency-tester.ts";
 
 // Define a logger type
@@ -72,7 +73,7 @@ export class CacheManager {
       } catch (e) {
         // Catch as unknown
         const error = e instanceof Error ? e : new Error(String(e)); // Ensure Error type
-        this.log("error", "CacheManager (Deno): Failed to open Deno KV store:", error);
+        this.log("error", "CacheManager (Deno): Failed to open Deno KV store:", redactRpcDiagnostic(error));
         throw new Error(`Failed to open Deno KV store: ${error.message}`);
       }
     }
@@ -83,7 +84,10 @@ export class CacheManager {
     if (this.disabled || this.cacheLoaded) return; // Skip if disabled
 
     // --- Deno KV Implementation ---
-    this.log("debug", `CacheManager (Deno): Attempting to load cache from Deno KV (key: ${this.cacheKey})`);
+    this.log(
+      "debug",
+      `CacheManager (Deno): Attempting to load cache from Deno KV (key: ${redactRpcDiagnostic(this.cacheKey)})`,
+    );
     try {
       const kv = await this.ensureKvOpen();
       // Use a single key to store the entire cache object
@@ -91,15 +95,25 @@ export class CacheManager {
 
       if (result.value !== null) {
         this.cache = result.value;
-        this.log("debug", `CacheManager (Deno): Loaded cache from Deno KV (key: ${this.cacheKey})`);
+        this.log(
+          "debug",
+          `CacheManager (Deno): Loaded cache from Deno KV (key: ${redactRpcDiagnostic(this.cacheKey)})`,
+        );
       } else {
-        this.log("debug", `CacheManager (Deno): No cache found in Deno KV (key: ${this.cacheKey})`);
+        this.log(
+          "debug",
+          `CacheManager (Deno): No cache found in Deno KV (key: ${redactRpcDiagnostic(this.cacheKey)})`,
+        );
         this.cache = {}; // Initialize empty if not found
       }
     } catch (e) {
       // Catch as unknown
       const error = e instanceof Error ? e : new Error(String(e)); // Ensure Error type
-      this.log("error", `CacheManager (Deno): Failed to load cache from Deno KV (key: ${this.cacheKey}):`, error);
+      this.log(
+        "error",
+        `CacheManager (Deno): Failed to load cache from Deno KV (key: ${redactRpcDiagnostic(this.cacheKey)}):`,
+        redactRpcDiagnostic(error),
+      );
       this.cache = {}; // Initialize empty on error
     }
     // --- End Deno KV ---
@@ -120,15 +134,22 @@ export class CacheManager {
     }
 
     // --- Deno KV Implementation ---
-    this.log("debug", `CacheManager (Deno): Attempting to save cache to Deno KV (key: ${this.cacheKey})`);
+    this.log(
+      "debug",
+      `CacheManager (Deno): Attempting to save cache to Deno KV (key: ${redactRpcDiagnostic(this.cacheKey)})`,
+    );
     try {
       const kv = await this.ensureKvOpen();
       await kv.set([this.cacheKey], this.cache);
-      this.log("debug", `CacheManager (Deno): Saved cache to Deno KV (key: ${this.cacheKey})`);
+      this.log("debug", `CacheManager (Deno): Saved cache to Deno KV (key: ${redactRpcDiagnostic(this.cacheKey)})`);
     } catch (e) {
       // Catch as unknown
       const error = e instanceof Error ? e : new Error(String(e)); // Ensure Error type
-      this.log("error", `CacheManager (Deno): Failed to save cache to Deno KV (key: ${this.cacheKey}):`, error);
+      this.log(
+        "error",
+        `CacheManager (Deno): Failed to save cache to Deno KV (key: ${redactRpcDiagnostic(this.cacheKey)}):`,
+        redactRpcDiagnostic(error),
+      );
     }
     // --- End Deno KV ---
   }
@@ -153,14 +174,18 @@ export class CacheManager {
     return null;
   }
 
-  async updateChainCache(chainId: number, latencyMap: Record<string, LatencyTestResult>, fastestRpc: string | null): Promise<void> {
+  async updateChainCache(
+    chainId: number,
+    latencyMap: Record<string, LatencyTestResult>,
+    fastestRpc: string | null,
+  ): Promise<void> {
     if (this.disabled) {
       this.log("debug", `CacheManager: Caching disabled, skipping cache update for chainId ${chainId}`);
       return; // Do nothing if disabled
     }
     await this.loadCache(); // Ensure loaded before update
     this.log("debug", `CacheManager: Updating cache for chainId ${chainId}`, {
-      fastestRpc,
+      fastestRpc: fastestRpc ? getRpcEndpointId(fastestRpc) : null,
       latencyMapCount: Object.keys(latencyMap || {}).length,
     });
     this.cache[chainId] = {
@@ -187,7 +212,7 @@ export class CacheManager {
    */
   async invalidateRpcInCache(chainId: number, rpcUrl: string, healthStatus: "eliminated"): Promise<void> {
     if (this.disabled) {
-      this.log("debug", `CacheManager: Caching disabled, skipping RPC invalidation for ${rpcUrl}`);
+      this.log("debug", `CacheManager: Caching disabled, skipping RPC invalidation for ${getRpcEndpointId(rpcUrl)}`);
       return;
     }
 
@@ -195,7 +220,7 @@ export class CacheManager {
     const chainCache = this.cache[chainId];
 
     if (!chainCache || !chainCache.latencyMap[rpcUrl]) {
-      this.log("warn", `CacheManager: Cannot invalidate RPC ${rpcUrl} - not found in cache`);
+      this.log("warn", `CacheManager: Cannot invalidate RPC ${getRpcEndpointId(rpcUrl)} - not found in cache`);
       return;
     }
 
@@ -223,7 +248,7 @@ export class CacheManager {
     }
 
     await this.saveCache();
-    this.log("info", `CacheManager: Marked RPC ${rpcUrl} as ${healthStatus} in cache`);
+    this.log("info", `CacheManager: Marked RPC ${getRpcEndpointId(rpcUrl)} as ${healthStatus} in cache`);
   }
 
   /**

--- a/packages/permit2-rpc-server/src/infra/latency-tester.ts
+++ b/packages/permit2-rpc-server/src/infra/latency-tester.ts
@@ -1,4 +1,5 @@
 import PERMIT2_BYTECODE_PREFIX from "../fixtures/permit2-bytecode.ts";
+import { getRpcEndpointId, redactRpcDiagnostic } from "../core/rpc-endpoint-id.ts";
 
 // --- Interfaces ---
 interface JsonRpcRequest {
@@ -23,7 +24,15 @@ interface JsonRpcResponse {
 type EthSyncingResult = false | Record<string, unknown>; // Use Record<string, unknown> instead of {}
 
 // Restore 'wrong_bytecode' status
-type LatencyTestStatus = "ok" | "syncing" | "wrong_bytecode" | "wrong_chain_id" | "timeout" | "http_error" | "rpc_error" | "network_error";
+type LatencyTestStatus =
+  | "ok"
+  | "syncing"
+  | "wrong_bytecode"
+  | "wrong_chain_id"
+  | "timeout"
+  | "http_error"
+  | "rpc_error"
+  | "network_error";
 
 export interface LatencyTestResult {
   url: string;
@@ -60,7 +69,7 @@ export class LatencyTester {
   private async _makeRpcCall(
     url: string,
     method: string,
-    params: unknown[] // Changed any[] to unknown[]
+    params: unknown[], // Changed any[] to unknown[]
   ): Promise<JsonRpcResponse> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
@@ -104,7 +113,10 @@ export class LatencyTester {
     let status: LatencyTestStatus = "network_error"; // Default to network error
 
     try {
-      const calls = [this._makeRpcCall(url, "eth_getCode", [PERMIT2_ADDRESS, "latest"]), this._makeRpcCall(url, "eth_syncing", [])];
+      const calls = [
+        this._makeRpcCall(url, "eth_getCode", [PERMIT2_ADDRESS, "latest"]),
+        this._makeRpcCall(url, "eth_syncing", []),
+      ];
 
       if (this.validateChainId) {
         calls.push(this._makeRpcCall(url, "eth_chainId", []));
@@ -126,8 +138,13 @@ export class LatencyTester {
         }
       }
       // Log expected "Failed to fetch" (likely CORS) at debug level, others at warn
-      const logLevel = status === "network_error" && err instanceof TypeError && err.message === "Failed to fetch" ? "debug" : "warn";
-      this.log(logLevel, `Latency test failed for ${url}: ${status} - ${err.message}`);
+      const logLevel = status === "network_error" && err instanceof TypeError && err.message === "Failed to fetch"
+        ? "debug"
+        : "warn";
+      this.log(
+        logLevel,
+        `Latency test failed for ${getRpcEndpointId(url)}: ${status} - ${redactRpcDiagnostic(err.message)}`,
+      );
       return { url, latency: Infinity, status, error: err.message };
     }
 
@@ -137,19 +154,19 @@ export class LatencyTester {
     if (getCodeResponse?.error) {
       status = "rpc_error";
       const errMsg = `eth_getCode RPC error ${getCodeResponse.error.code} - ${getCodeResponse.error.message}`;
-      this.log("warn", `Latency test failed for ${url}: ${errMsg}`);
+      this.log("warn", `Latency test failed for ${getRpcEndpointId(url)}: ${redactRpcDiagnostic(errMsg)}`);
       return { url, latency: Infinity, status, error: errMsg };
     }
     if (syncingResponse?.error) {
       status = "rpc_error";
       const errMsg = `eth_syncing RPC error ${syncingResponse.error.code} - ${syncingResponse.error.message}`;
-      this.log("warn", `Latency test failed for ${url}: ${errMsg}`);
+      this.log("warn", `Latency test failed for ${getRpcEndpointId(url)}: ${redactRpcDiagnostic(errMsg)}`);
       return { url, latency: Infinity, status, error: errMsg };
     }
     if (chainIdResponse?.error) {
       status = "rpc_error";
       const errMsg = `eth_chainId RPC error ${chainIdResponse.error.code} - ${chainIdResponse.error.message}`;
-      this.log("warn", `Latency test failed for ${url}: ${errMsg}`);
+      this.log("warn", `Latency test failed for ${getRpcEndpointId(url)}: ${redactRpcDiagnostic(errMsg)}`);
       return { url, latency: Infinity, status, error: errMsg };
     }
 
@@ -167,14 +184,14 @@ export class LatencyTester {
       if (observedChainId === undefined) {
         status = "rpc_error";
         const errMsg = `Invalid eth_chainId result: ${JSON.stringify(chainIdResponse?.result)}`;
-        this.log("warn", `Latency test failed for ${url}: ${errMsg}`);
+        this.log("warn", `Latency test failed for ${getRpcEndpointId(url)}: ${redactRpcDiagnostic(errMsg)}`);
         return { url, latency: Infinity, status, error: errMsg };
       }
 
       if (observedChainId !== chainId) {
         status = "wrong_chain_id";
         const errMsg = `Chain ID mismatch: expected ${chainId}, got ${observedChainId}`;
-        this.log("warn", `RPC ${url} returned wrong chainId: ${errMsg}`);
+        this.log("warn", `RPC ${getRpcEndpointId(url)} returned wrong chainId: ${redactRpcDiagnostic(errMsg)}`);
         return { url, latency, status, error: errMsg, observedChainId };
       }
     }
@@ -183,7 +200,7 @@ export class LatencyTester {
     if (syncingResponse?.result !== false) {
       status = "syncing";
       const errMsg = `Node is not synced (eth_syncing returned ${JSON.stringify(syncingResponse?.result)})`;
-      this.log("warn", `RPC ${url} is syncing: ${errMsg}`);
+      this.log("warn", `RPC ${getRpcEndpointId(url)} is syncing: ${redactRpcDiagnostic(errMsg)}`);
       // Return actual latency for syncing nodes so they can be used as fallback
       return { url, latency, status, error: errMsg };
     }
@@ -192,14 +209,17 @@ export class LatencyTester {
     if (typeof getCodeResponse?.result !== "string") {
       status = "wrong_bytecode";
       const errMsg = `Invalid bytecode response type: ${typeof getCodeResponse?.result}`;
-      this.log("warn", `RPC ${url} returned invalid bytecode: ${errMsg}`);
+      this.log("warn", `RPC ${getRpcEndpointId(url)} returned invalid bytecode: ${redactRpcDiagnostic(errMsg)}`);
       // Return actual latency even for wrong bytecode, in case it's needed for basic operations
       return { url, latency, status, error: errMsg };
     }
 
     // Log first 100 chars of both expected and received for debugging (use debug level)
     this.log("debug", `\nExpected Permit2 prefix (first 100 chars): ${PERMIT2_BYTECODE_PREFIX.slice(0, 100)}`);
-    this.log("debug", `Received bytecode (first 100 chars): ${getCodeResponse.result.slice(0, 100)}`);
+    this.log(
+      "debug",
+      `Received bytecode (first 100 chars): ${redactRpcDiagnostic(getCodeResponse.result.slice(0, 100))}`,
+    );
 
     if (!getCodeResponse.result.startsWith(PERMIT2_BYTECODE_PREFIX)) {
       status = "wrong_bytecode";
@@ -213,14 +233,14 @@ export class LatencyTester {
         commonPrefixLength++;
       }
       const errMsg = `Bytecode mismatch at position ${commonPrefixLength}`;
-      this.log("warn", `RPC ${url} has incorrect bytecode: ${errMsg}`);
+      this.log("warn", `RPC ${getRpcEndpointId(url)} has incorrect bytecode: ${redactRpcDiagnostic(errMsg)}`);
       // Return actual latency even for wrong bytecode, in case it's needed for basic operations
       return { url, latency, status, error: errMsg };
     }
 
     // All checks passed - node is synced and has correct bytecode
     status = "ok";
-    this.log("debug", `RPC ${url} passed all checks (${latency}ms)`);
+    this.log("debug", `RPC ${getRpcEndpointId(url)} passed all checks (${latency}ms)`);
     return { url, latency, status };
   }
 
@@ -229,7 +249,10 @@ export class LatencyTester {
    */
   async testRpcUrls(chainId: number, urls: string[]): Promise<Record<string, LatencyTestResult>> {
     if (!urls || urls.length === 0) return {};
-    this.log("info", `Starting latency tests for chain ${chainId} across ${urls.length} RPC URLs (incl. chainId, sync & bytecode check)...`);
+    this.log(
+      "info",
+      `Starting latency tests for chain ${chainId} across ${urls.length} RPC URLs (incl. chainId, sync & bytecode check)...`,
+    );
 
     const results = await Promise.allSettled(urls.map((url) => this.testSingleRpc(chainId, url)));
     const resultMap: Record<string, LatencyTestResult> = {};
@@ -243,7 +266,11 @@ export class LatencyTester {
       if (result.status === "fulfilled") {
         resultMap[url] = result.value;
       } else {
-        this.log("error", `Unexpected rejection during latency test promise for ${url}:`, result.reason);
+        this.log(
+          "error",
+          `Unexpected rejection during latency test promise for ${getRpcEndpointId(url)}:`,
+          redactRpcDiagnostic(result.reason),
+        );
         resultMap[url] = {
           url,
           latency: Infinity,

--- a/packages/permit2-rpc-server/src/infra/latency-tester_test.ts
+++ b/packages/permit2-rpc-server/src/infra/latency-tester_test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "jsr:@std/assert@1";
+import { getRpcEndpointId } from "../core/rpc-endpoint-id.ts";
 import { LatencyTester } from "./latency-tester.ts";
 import PERMIT2_BYTECODE_PREFIX from "../fixtures/permit2-bytecode.ts";
 
@@ -29,7 +30,7 @@ Deno.test("LatencyTester: eth_chainId mismatch returns wrong_chain_id", async ()
         new Response(JSON.stringify(makeJsonRpcResponse(body.id, result)), {
           status: 200,
           headers: { "Content-Type": "application/json" },
-        })
+        }),
       );
     }) as typeof fetch;
 
@@ -39,6 +40,47 @@ Deno.test("LatencyTester: eth_chainId mismatch returns wrong_chain_id", async ()
 
     assertEquals(results[url]?.status, "wrong_chain_id");
     assertEquals(results[url]?.observedChainId, 2);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+Deno.test("LatencyTester: redacts upstream URLs from emitted diagnostics", async () => {
+  const realFetch = globalThis.fetch;
+  const endpoint = "https://user:secret@rpc.example/private?token=endpoint-token";
+  const providerUrl = "https://provider.example/diagnostic?token=provider-token";
+  const logs: Array<{ message: string; optionalParams: unknown[] }> = [];
+
+  try {
+    globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) : {};
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: body.id,
+            error: { code: -32000, message: `Provider diagnostic: ${providerUrl}` },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+    }) as typeof fetch;
+
+    const tester = new LatencyTester(
+      250,
+      (_level, message, ...optionalParams) => logs.push({ message, optionalParams }),
+    );
+    const results = await tester.testRpcUrls(1, [endpoint]);
+    const diagnostics = JSON.stringify(logs);
+
+    assertEquals(diagnostics.includes(endpoint), false);
+    assertEquals(diagnostics.includes(providerUrl), false);
+    assertEquals(diagnostics.includes(getRpcEndpointId(endpoint)), true);
+    assertEquals(diagnostics.includes(getRpcEndpointId(providerUrl)), true);
+    assertEquals(results[endpoint]?.error?.includes(providerUrl), true);
   } finally {
     globalThis.fetch = realFetch;
   }

--- a/packages/permit2-rpc-server/src/infra/ws-latency-tester.ts
+++ b/packages/permit2-rpc-server/src/infra/ws-latency-tester.ts
@@ -1,5 +1,6 @@
 /// <reference lib="deno.ns" />
 import PERMIT2_BYTECODE_PREFIX from "../fixtures/permit2-bytecode.ts";
+import { getRpcEndpointId, redactRpcDiagnostic } from "../core/rpc-endpoint-id.ts";
 import type { LatencyTestResult } from "./latency-tester.ts";
 
 interface JsonRpcRequest {
@@ -94,7 +95,7 @@ class WsJsonRpcClient {
       try {
         parsed = JSON.parse(raw);
       } catch (error) {
-        this.log("debug", "WS JSON-RPC parse error", error);
+        this.log("debug", "WS JSON-RPC parse error", redactRpcDiagnostic(error));
         return;
       }
       if (!parsed || typeof parsed !== "object" || !("id" in parsed)) return;
@@ -166,35 +167,41 @@ export class WsLatencyTester {
       ws = await openWs(url, this.timeoutMs);
       const client = new WsJsonRpcClient(ws, this.timeoutMs, this.log);
 
-      const [getCodeResponse, syncingResponse] = await Promise.all([client.call("eth_getCode", [PERMIT2_ADDRESS, "latest"]), client.call("eth_syncing", [])]);
+      const [getCodeResponse, syncingResponse] = await Promise.all([
+        client.call("eth_getCode", [PERMIT2_ADDRESS, "latest"]),
+        client.call("eth_syncing", []),
+      ]);
 
       const latency = Date.now() - startTime;
 
       if (getCodeResponse?.error) {
         const errMsg = `eth_getCode RPC error ${getCodeResponse.error.code} - ${getCodeResponse.error.message}`;
-        this.log("warn", `WS latency test failed for ${url}: ${errMsg}`);
+        this.log("warn", `WS latency test failed for ${getRpcEndpointId(url)}: ${redactRpcDiagnostic(errMsg)}`);
         return { url, latency: Infinity, status: "rpc_error", error: errMsg };
       }
       if (syncingResponse?.error) {
         const errMsg = `eth_syncing RPC error ${syncingResponse.error.code} - ${syncingResponse.error.message}`;
-        this.log("warn", `WS latency test failed for ${url}: ${errMsg}`);
+        this.log("warn", `WS latency test failed for ${getRpcEndpointId(url)}: ${redactRpcDiagnostic(errMsg)}`);
         return { url, latency: Infinity, status: "rpc_error", error: errMsg };
       }
 
       if (syncingResponse?.result !== false) {
         const errMsg = `Node is not synced (eth_syncing returned ${JSON.stringify(syncingResponse?.result)})`;
-        this.log("warn", `WS RPC ${url} is syncing: ${errMsg}`);
+        this.log("warn", `WS RPC ${getRpcEndpointId(url)} is syncing: ${redactRpcDiagnostic(errMsg)}`);
         return { url, latency, status: "syncing", error: errMsg };
       }
 
       if (typeof getCodeResponse?.result !== "string") {
         const errMsg = `Invalid bytecode response type: ${typeof getCodeResponse?.result}`;
-        this.log("warn", `WS RPC ${url} returned invalid bytecode: ${errMsg}`);
+        this.log("warn", `WS RPC ${getRpcEndpointId(url)} returned invalid bytecode: ${redactRpcDiagnostic(errMsg)}`);
         return { url, latency, status: "wrong_bytecode", error: errMsg };
       }
 
       this.log("debug", `\nExpected Permit2 prefix (first 100 chars): ${PERMIT2_BYTECODE_PREFIX.slice(0, 100)}`);
-      this.log("debug", `Received bytecode (first 100 chars): ${getCodeResponse.result.slice(0, 100)}`);
+      this.log(
+        "debug",
+        `Received bytecode (first 100 chars): ${redactRpcDiagnostic(getCodeResponse.result.slice(0, 100))}`,
+      );
 
       if (!getCodeResponse.result.startsWith(PERMIT2_BYTECODE_PREFIX)) {
         let commonPrefixLength = 0;
@@ -206,17 +213,20 @@ export class WsLatencyTester {
           commonPrefixLength++;
         }
         const errMsg = `Bytecode mismatch at position ${commonPrefixLength}`;
-        this.log("warn", `WS RPC ${url} has incorrect bytecode: ${errMsg}`);
+        this.log("warn", `WS RPC ${getRpcEndpointId(url)} has incorrect bytecode: ${redactRpcDiagnostic(errMsg)}`);
         return { url, latency, status: "wrong_bytecode", error: errMsg };
       }
 
-      this.log("debug", `WS RPC ${url} passed all checks (${latency}ms)`);
+      this.log("debug", `WS RPC ${getRpcEndpointId(url)} passed all checks (${latency}ms)`);
       return { url, latency, status: "ok" };
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       const status = err.message.toLowerCase().includes("timed out") ? "timeout" : "network_error";
       const logLevel = status === "network_error" ? "debug" : "warn";
-      this.log(logLevel, `WS latency test failed for ${url}: ${status} - ${err.message}`);
+      this.log(
+        logLevel,
+        `WS latency test failed for ${getRpcEndpointId(url)}: ${status} - ${redactRpcDiagnostic(err.message)}`,
+      );
       return { url, latency: Infinity, status, error: err.message };
     } finally {
       try {
@@ -243,7 +253,11 @@ export class WsLatencyTester {
       if (result.status === "fulfilled") {
         resultMap[url] = result.value;
       } else {
-        this.log("error", `Unexpected rejection during WS latency test promise for ${url}:`, result.reason);
+        this.log(
+          "error",
+          `Unexpected rejection during WS latency test promise for ${getRpcEndpointId(url)}:`,
+          redactRpcDiagnostic(result.reason),
+        );
         resultMap[url] = {
           url,
           latency: Infinity,

--- a/packages/permit2-rpc-server/src/mcp/handler.ts
+++ b/packages/permit2-rpc-server/src/mcp/handler.ts
@@ -1,4 +1,5 @@
 import type { Permit2RpcManager } from "../core/permit2-rpc-manager.ts";
+import { redactRpcDiagnostic } from "../core/rpc-endpoint-id.ts";
 import { buildRpcParams } from "./ethereum-rpc-params.ts";
 import { getEthereumTools } from "./ethereum-tools.ts";
 
@@ -23,7 +24,9 @@ export function isMcpRequest(body: unknown): boolean {
   if (typeof body === "object" && body !== null && "method" in body) {
     const method = (body as any).method;
     return (
-      typeof method === "string" && (method === "initialize" || method.startsWith("tools/") || method.startsWith("resources/") || method.startsWith("prompts/"))
+      typeof method === "string" &&
+      (method === "initialize" || method.startsWith("tools/") || method.startsWith("resources/") ||
+        method.startsWith("prompts/"))
     );
   }
   return false;
@@ -88,7 +91,7 @@ export async function handleMcpRequest(options: {
         mcpResponse = {
           error: {
             code: -32603,
-            message: error.message,
+            message: redactRpcDiagnostic(error.message),
           },
         };
       }
@@ -114,6 +117,6 @@ export async function handleMcpRequest(options: {
     {
       status: 200,
       headers: { ...options.corsHeaders, "Content-Type": "application/json" },
-    }
+    },
   );
 }


### PR DESCRIPTION
## Summary
- classify JSON-RPC quota errors `-32004` and `-32005` for healthy-endpoint failover
- admit one half-open recovery probe per completed backoff window
- replace exposed endpoint URLs in health, logs, and serialized errors with stable opaque IDs
- make sequential override ordering authoritative and retain JSON-RPC batch ID `0`
- preserve Multicall3 eligibility and sender-sensitive exclusions

## Validation
- `deno task build`
- `deno task test` (51 passed)
- `deno fmt --check`
- `git diff --check`

## Note
`deno lint` still reports three pre-existing `require-await` findings in `src/core/rpc-selector_test.ts`; they are outside this scoped hardening patch.