### PR TITLE
fix(rpc): complete RPC hardening bundle

### DIFF
--- a/docs/erpc-upstream-delta-a698f1d4-to-8459b053.md
+++ b/docs/erpc-upstream-delta-a698f1d4-to-8459b053.md
@@ -15,6 +15,23 @@
 | Upstream dates          | 2025-12-17 through 2026-07-23                                                                                                                               |
 | GitHub comparison       | [Compare the exact audited range](https://github.com/erpc/erpc/compare/a698f1d4350e43c960c6f8a2ed18b85c226b7a8e...8459b05354b0834e0e140621e54a9233d2abb790) |
 
+## Post-implementation correction and resolution
+
+The audit text below is retained as the historical review record. Its references
+to `-32004/-32005` as quota codes and to an unqualified recovery-probe guarantee
+are superseded by this correction:
+
+- `-32004` is `METHOD_NOT_SUPPORTED`, not a quota code. Together with `-32601`
+  (`METHOD_NOT_FOUND`), it is an endpoint/method capability result: fail over
+  where another endpoint may support the method, without a health, scorer,
+  throttle, or circuit penalty.
+- `-32005` is `LIMIT_EXCEEDED`. It fails over with backoff and throttle
+  accounting.
+- Recovery-lease exclusivity is per `Permit2RpcManager` instance within its
+  isolate, using an opaque lease token. It provides no coordination across
+  manager instances or isolates, and no Deno KV admission check is performed on
+  the request path.
+
 ## Executive Summary
 
 The eRPC research submodule is pinned at `a698f1d4`, while eRPC's `main` branch is

--- a/packages/permit2-rpc-server/src/core/circuit-breaker-v2.ts
+++ b/packages/permit2-rpc-server/src/core/circuit-breaker-v2.ts
@@ -29,7 +29,7 @@ const DEFAULT_HALF_OPEN_TEST_LIMIT = 3;
 
 const PROVIDER_FAULT_REASONS = new Set<string>([
   "rate_limit",
-  "quota_exceeded",
+  "limit_exceeded",
   "server_error",
   "timeout",
   "network_error",

--- a/packages/permit2-rpc-server/src/core/consensus.ts
+++ b/packages/permit2-rpc-server/src/core/consensus.ts
@@ -16,6 +16,14 @@ export interface ConsensusOptions {
   preferNonEmpty?: boolean;
 }
 
+/** Signals that the caller error is deterministic and must win over quorum. */
+export class ConsensusNonRetryableError extends Error {
+  constructor(public override readonly cause: unknown) {
+    super("Non-retryable error during consensus request");
+    this.name = "ConsensusNonRetryableError";
+  }
+}
+
 function stableStringify(value: unknown): string {
   if (value === null || value === undefined) return JSON.stringify(value);
 
@@ -52,15 +60,24 @@ function isNonEmpty(value: unknown): boolean {
 export class ConsensusExecutor {
   constructor(private readonly metrics: RpcMetricsRegistry) {}
 
-  async execute<T>(chainId: number, method: string, candidates: string[], requestFn: (rpcUrl: string) => Promise<T>, config: ConsensusConfig): Promise<T> {
+  async execute<T>(
+    chainId: number,
+    method: string,
+    candidates: string[],
+    requestFn: (rpcUrl: string) => Promise<T>,
+    config: ConsensusConfig,
+  ): Promise<T> {
     const participantCount = Math.min(Math.max(1, config.participants), candidates.length);
     const quorum = Math.min(Math.max(1, config.agreementThreshold), participantCount);
     const selected = candidates.slice(0, participantCount);
 
-    const results = await Promise.allSettled(selected.map(async (rpcUrl) => ({ rpcUrl, value: await requestFn(rpcUrl) })));
+    const results = await Promise.allSettled(
+      selected.map(async (rpcUrl) => ({ rpcUrl, value: await requestFn(rpcUrl) })),
+    );
 
     const successes: Array<{ rpcUrl: string; value: T; key: string }> = [];
     let lastError: unknown;
+    let nonRetryableError: unknown;
 
     for (const res of results) {
       if (res.status === "fulfilled") {
@@ -68,11 +85,20 @@ export class ConsensusExecutor {
         successes.push({ rpcUrl: res.value.rpcUrl, value: res.value.value, key });
       } else {
         lastError = res.reason;
+        if (res.reason instanceof ConsensusNonRetryableError) {
+          nonRetryableError ??= res.reason.cause;
+        }
       }
     }
 
+    if (nonRetryableError !== undefined) {
+      throw nonRetryableError instanceof Error ? nonRetryableError : new Error(String(nonRetryableError));
+    }
+
     if (successes.length === 0) {
-      throw lastError instanceof Error ? lastError : new Error(String(lastError ?? "Consensus: all participants failed"));
+      throw lastError instanceof Error
+        ? lastError
+        : new Error(String(lastError ?? "Consensus: all participants failed"));
     }
 
     const buckets = new Map<string, Array<{ rpcUrl: string; value: T }>>();

--- a/packages/permit2-rpc-server/src/core/permit2-rpc-manager.ts
+++ b/packages/permit2-rpc-server/src/core/permit2-rpc-manager.ts
@@ -385,6 +385,16 @@ export class Permit2RpcManager {
         }
 
         if (httpStatus >= 400 && httpStatus <= 499) {
+          // A structured quota code is more specific than a provider's generic
+          // 4xx wrapper, so preserve healthy-endpoint failover.
+          if (code === JSON_RPC_ERROR_CODES.QUOTA_EXCEEDED || code === JSON_RPC_ERROR_CODES.REQUEST_LIMIT) {
+            return {
+              behavior: ErrorBehavior.RETRY_WITH_BACKOFF,
+              reason: "quota_exceeded",
+              isProviderIssue: true,
+            };
+          }
+
           // The HTTP status is client-facing, but a body we could not decode
           // cannot establish that the caller made a bad JSON-RPC request.
           if (error instanceof InvalidJsonResponseError) {

--- a/packages/permit2-rpc-server/src/core/permit2-rpc-manager.ts
+++ b/packages/permit2-rpc-server/src/core/permit2-rpc-manager.ts
@@ -14,7 +14,7 @@ import { HeadTracker } from "./head-tracker.ts";
 import { HEDGE_ABORT_REASON, HedgedNonRetryableError, HedgedRequester } from "./hedged-requester.ts";
 import type { HedgeConfig } from "./hedged-requester.ts";
 import { isWriteMethod } from "./method-classifier.ts";
-import { ConsensusExecutor } from "./consensus.ts";
+import { ConsensusExecutor, ConsensusNonRetryableError } from "./consensus.ts";
 import type { ConsensusConfig, ConsensusOptions } from "./consensus.ts";
 import { getRpcEndpointId, redactRpcDiagnostic } from "./rpc-endpoint-id.ts";
 
@@ -36,8 +36,8 @@ const JSON_RPC_ERROR_CODES = {
   UNAUTHORIZED: -32001,
   ACTION_NOT_PERMITTED: -32002,
   EXECUTION_ERROR: -32003,
-  QUOTA_EXCEEDED: -32004,
-  REQUEST_LIMIT: -32005,
+  METHOD_NOT_SUPPORTED: -32004,
+  LIMIT_EXCEEDED: -32005,
 } as const;
 
 type SendOptions = {
@@ -60,6 +60,48 @@ const normalizeRpcList = (values: string[] | undefined): string[] => {
   return out;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+
+const hasOwn = (value: object, key: string): boolean => Object.prototype.hasOwnProperty.call(value, key);
+
+const isJsonRpcResponseId = (value: unknown): value is number | string | null => {
+  return typeof value === "number" || typeof value === "string" || value === null;
+};
+
+const isJsonRpcErrorObject = (value: unknown): value is { code: number; message: string; data?: unknown } => {
+  return isRecord(value) && typeof value.code === "number" && typeof value.message === "string";
+};
+
+/**
+ * An upstream result is trusted only after it satisfies the JSON-RPC response
+ * envelope. JSON that is not a JSON-RPC response is a provider-body failure,
+ * not a successful `undefined` result.
+ */
+const isJsonRpcResponseEnvelope = (value: unknown): value is Record<string, unknown> => {
+  if (!isRecord(value) || value.jsonrpc !== "2.0" || !hasOwn(value, "id") || !isJsonRpcResponseId(value.id)) {
+    return false;
+  }
+
+  const hasResult = hasOwn(value, "result");
+  const hasError = hasOwn(value, "error");
+  if (hasResult === hasError) return false;
+
+  return hasResult || isJsonRpcErrorObject(value.error);
+};
+
+const isDeterministicExecutionRevert = (code: number, message: string): boolean => {
+  if (code === JSON_RPC_ERROR_CODES.EXECUTION_REVERTED) return true;
+  if (code !== JSON_RPC_ERROR_CODES.IMPLEMENTATION_DEFINED_START) return false;
+
+  return /\bexecution reverted\b|\bvm exception\b.*\brevert(?:ed)?\b|\binvalid opcode\b|\bcall exception\b/i.test(
+    message,
+  );
+};
+
+type UpstreamErrorSource = "provider_jsonrpc" | "transport" | "invalid_body";
+
 class JsonRpcError extends Error {
   public data?: unknown;
   public httpStatus?: number;
@@ -69,6 +111,7 @@ class JsonRpcError extends Error {
     message: string,
     data?: unknown,
     httpStatus?: number,
+    public source: UpstreamErrorSource = "provider_jsonrpc",
   ) {
     super(redactRpcDiagnostic(message));
     this.name = "JsonRpcError";
@@ -77,7 +120,7 @@ class JsonRpcError extends Error {
   }
 }
 
-/** An upstream response body could not be decoded as JSON. */
+/** An upstream response body was not a valid JSON-RPC response. */
 class InvalidJsonResponseError extends JsonRpcError {
   constructor(httpStatus?: number) {
     super(
@@ -85,6 +128,7 @@ class InvalidJsonResponseError extends JsonRpcError {
       "Invalid JSON response from provider",
       undefined,
       httpStatus,
+      "invalid_body",
     );
     this.name = "InvalidJsonResponseError";
   }
@@ -114,12 +158,14 @@ interface RpcHealthState {
   lastFailureTime: number;
   lastSuccessTime: number;
   temporaryUnavailableUntil?: number;
-  recoveryProbeInFlight?: boolean;
+  recoveryProbeToken?: string;
   failureReasons: Map<string, number>; // reason -> count
 }
 
 interface RpcAttemptLease {
-  recoveryProbe: boolean;
+  kind: "normal" | "recovery";
+  token?: string;
+  expiredBackoffUntil?: number;
 }
 
 class RpcAttemptUnavailableError extends Error {
@@ -141,6 +187,7 @@ interface ErrorClassification {
   behavior: ErrorBehavior;
   reason: string;
   isProviderIssue: boolean;
+  methodUnsupported?: boolean;
 }
 
 type ScoringV2Options = Partial<ScoringConfig> & { enabled?: boolean };
@@ -214,6 +261,8 @@ export class Permit2RpcManager {
   private maxConsecutiveFailures: number;
   private backoffBaseMs: number;
   private maxBackoffMs: number;
+  private readonly recoveryLeaseOwner = crypto.randomUUID();
+  private recoveryLeaseSequence = 0;
 
   // Round-robin tracking
   private rpcIndexMap = new Map<number, number>();
@@ -254,7 +303,13 @@ export class Permit2RpcManager {
     });
     this.validateChainId = options.validateChainId ?? true;
     this.latencyTester = new LatencyTester(options.latencyTimeoutMs, logger, { validateChainId: this.validateChainId });
-    this.rpcSelector = new RpcSelector(this.dataSource, this.cacheManager, this.latencyTester, logger);
+    this.rpcSelector = new RpcSelector(
+      this.dataSource,
+      this.cacheManager,
+      this.latencyTester,
+      logger,
+      (rpcUrl) => this.isRpcDiagnosticEligible(rpcUrl),
+    );
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
     this.maxConsecutiveFailures = options.maxConsecutiveFailures ?? DEFAULT_MAX_CONSECUTIVE_FAILURES;
@@ -325,169 +380,138 @@ export class Permit2RpcManager {
   }
 
   /**
-   * Classify errors based on their characteristics, not string parsing
+   * Classify a synthesized upstream transport failure. A malformed response
+   * follows explicit transport statuses (such as 429) but remains provider-owned
+   * under a generic 4xx because it cannot establish caller invalidity.
    */
-  private classifyError(error: Error): ErrorClassification {
-    // Check JSON-RPC errors first (most structured)
-    if (error instanceof JsonRpcError) {
-      const { code, httpStatus } = error;
+  private classifyTransportStatus(httpStatus: number | undefined, invalidBody = false): ErrorClassification {
+    if (httpStatus === 429) {
+      return {
+        behavior: ErrorBehavior.RETRY_WITH_BACKOFF,
+        reason: "rate_limit",
+        isProviderIssue: true,
+      };
+    }
 
-      // HTTP status takes precedence for network-level issues
-      if (httpStatus) {
-        if (httpStatus === 429) {
-          return {
-            behavior: ErrorBehavior.RETRY_WITH_BACKOFF,
-            reason: "rate_limit",
-            isProviderIssue: true,
-          };
-        }
+    if (httpStatus === 408) {
+      return {
+        behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
+        reason: "timeout",
+        isProviderIssue: true,
+      };
+    }
 
-        if (httpStatus === 401) {
-          // Unauthorized (missing/invalid credentials) for this upstream; try a different RPC.
-          return {
-            behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
-            reason: "unauthorized",
-            isProviderIssue: true,
-          };
-        }
+    if (httpStatus === 401) {
+      return {
+        behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
+        reason: "unauthorized",
+        isProviderIssue: true,
+      };
+    }
 
-        if (httpStatus === 403) {
-          // 403 with specific JSON-RPC codes indicates quota
-          if (code === JSON_RPC_ERROR_CODES.QUOTA_EXCEEDED || code === JSON_RPC_ERROR_CODES.REQUEST_LIMIT) {
-            return {
-              behavior: ErrorBehavior.RETRY_WITH_BACKOFF,
-              reason: "quota_exceeded",
-              isProviderIssue: true,
-            };
-          }
-          // Other 403s are usually upstream permission/billing issues; try a different RPC.
-          return {
-            behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
-            reason: "forbidden",
-            isProviderIssue: true,
-          };
-        }
+    if (httpStatus === 403) {
+      return {
+        behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
+        reason: "forbidden",
+        isProviderIssue: true,
+      };
+    }
 
-        if (httpStatus >= 500 && httpStatus <= 599) {
-          return {
-            behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
-            reason: "server_error",
-            isProviderIssue: true,
-          };
-        }
+    if (typeof httpStatus === "number" && httpStatus >= 500 && httpStatus <= 599) {
+      return {
+        behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
+        reason: "server_error",
+        isProviderIssue: true,
+      };
+    }
 
-        if (httpStatus === 408) {
-          return {
-            behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
-            reason: "timeout",
-            isProviderIssue: true,
-          };
-        }
-
-        if (httpStatus >= 400 && httpStatus <= 499) {
-          // A structured quota code is more specific than a provider's generic
-          // 4xx wrapper, so preserve healthy-endpoint failover.
-          if (code === JSON_RPC_ERROR_CODES.QUOTA_EXCEEDED || code === JSON_RPC_ERROR_CODES.REQUEST_LIMIT) {
-            return {
-              behavior: ErrorBehavior.RETRY_WITH_BACKOFF,
-              reason: "quota_exceeded",
-              isProviderIssue: true,
-            };
-          }
-
-          // The HTTP status is client-facing, but a body we could not decode
-          // cannot establish that the caller made a bad JSON-RPC request.
-          if (error instanceof InvalidJsonResponseError) {
-            return {
-              behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
-              reason: "invalid_json_response",
-              isProviderIssue: true,
-            };
-          }
-
-          return {
-            behavior: ErrorBehavior.DO_NOT_RETRY,
-            reason: "client_error",
-            isProviderIssue: false,
-          };
-        }
-      }
-
-      // A non-JSON response with no HTTP error status is still an upstream
-      // failure. A provider-supplied JSON-RPC parse error remains subject to
-      // the normal JSON-RPC error classification below.
-      if (error instanceof InvalidJsonResponseError) {
+    if (typeof httpStatus === "number" && httpStatus >= 400 && httpStatus <= 499) {
+      if (invalidBody) {
         return {
           behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
           reason: "invalid_json_response",
           isProviderIssue: true,
         };
       }
-
-      // JSON-RPC error codes
-      if (code === JSON_RPC_ERROR_CODES.INVALID_REQUEST || code === JSON_RPC_ERROR_CODES.INVALID_PARAMS) {
-        return {
-          behavior: ErrorBehavior.DO_NOT_RETRY,
-          reason: code === JSON_RPC_ERROR_CODES.INVALID_PARAMS ? "invalid_params" : "invalid_request",
-          isProviderIssue: false,
-        };
-      }
-
-      if (code === JSON_RPC_ERROR_CODES.EXECUTION_REVERTED) {
-        return {
-          behavior: ErrorBehavior.BLOCKCHAIN_ERROR,
-          reason: "execution_reverted",
-          isProviderIssue: false,
-        };
-      }
-
-      if (code === JSON_RPC_ERROR_CODES.METHOD_NOT_FOUND) {
-        return {
-          behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
-          reason: "method_not_found",
-          isProviderIssue: true,
-        };
-      }
-
-      if (code === JSON_RPC_ERROR_CODES.INTERNAL_ERROR) {
-        return {
-          behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
-          reason: "internal_error",
-          isProviderIssue: true,
-        };
-      }
-
-      if (code === JSON_RPC_ERROR_CODES.QUOTA_EXCEEDED || code === JSON_RPC_ERROR_CODES.REQUEST_LIMIT) {
-        return {
-          behavior: ErrorBehavior.RETRY_WITH_BACKOFF,
-          reason: "quota_exceeded",
-          isProviderIssue: true,
-        };
-      }
-
-      if (
-        code <= JSON_RPC_ERROR_CODES.IMPLEMENTATION_DEFINED_START &&
-        code >= JSON_RPC_ERROR_CODES.IMPLEMENTATION_DEFINED_END
-      ) {
-        // Other implementation-defined errors are usually retryable
-        return {
-          behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
-          reason: "provider_error",
-          isProviderIssue: true,
-        };
-      }
-
-      // Standard JSON-RPC errors (default: client-side)
-      if (code <= -32000 && code >= -32768) {
-        return {
-          behavior: ErrorBehavior.DO_NOT_RETRY,
-          reason: "json_rpc_error",
-          isProviderIssue: false,
-        };
-      }
+      return {
+        behavior: ErrorBehavior.DO_NOT_RETRY,
+        reason: "client_error",
+        isProviderIssue: false,
+      };
     }
 
-    // Network errors
+    if (invalidBody) {
+      return {
+        behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
+        reason: "invalid_json_response",
+        isProviderIssue: true,
+      };
+    }
+
+    return {
+      behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
+      reason: "provider_error",
+      isProviderIssue: true,
+    };
+  }
+
+  /**
+   * Classify errors based on decoded JSON-RPC semantics first, then transport.
+   */
+  private classifyError(error: Error): ErrorClassification {
+    if (error instanceof JsonRpcError) {
+      if (error.source === "provider_jsonrpc") {
+        const { code } = error;
+
+        // A decoded provider error has more information than any HTTP wrapper.
+        if (code === JSON_RPC_ERROR_CODES.INVALID_REQUEST || code === JSON_RPC_ERROR_CODES.PARSE_ERROR) {
+          return {
+            behavior: ErrorBehavior.DO_NOT_RETRY,
+            reason: code === JSON_RPC_ERROR_CODES.INVALID_REQUEST ? "invalid_request" : "parse_error",
+            isProviderIssue: false,
+          };
+        }
+
+        if (code === JSON_RPC_ERROR_CODES.INVALID_PARAMS) {
+          return {
+            behavior: ErrorBehavior.DO_NOT_RETRY,
+            reason: "invalid_params",
+            isProviderIssue: false,
+          };
+        }
+
+        if (isDeterministicExecutionRevert(code, error.message)) {
+          return {
+            behavior: ErrorBehavior.BLOCKCHAIN_ERROR,
+            reason: "execution_reverted",
+            isProviderIssue: false,
+          };
+        }
+
+        if (
+          code === JSON_RPC_ERROR_CODES.METHOD_NOT_FOUND ||
+          code === JSON_RPC_ERROR_CODES.METHOD_NOT_SUPPORTED
+        ) {
+          return {
+            behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
+            reason: "method_not_supported",
+            isProviderIssue: false,
+            methodUnsupported: true,
+          };
+        }
+
+        if (code === JSON_RPC_ERROR_CODES.LIMIT_EXCEEDED) {
+          return {
+            behavior: ErrorBehavior.RETRY_WITH_BACKOFF,
+            reason: "limit_exceeded",
+            isProviderIssue: true,
+          };
+        }
+      }
+
+      return this.classifyTransportStatus(error.httpStatus, error.source === "invalid_body");
+    }
+
     if (error.name === "AbortError") {
       return {
         behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
@@ -504,7 +528,6 @@ export class Permit2RpcManager {
       };
     }
 
-    // Default: assume it's retryable
     return {
       behavior: ErrorBehavior.RETRY_DIFFERENT_RPC,
       reason: "unknown_error",
@@ -556,15 +579,25 @@ export class Permit2RpcManager {
   }
 
   /**
+   * Background diagnostics must not consume a foreground recovery opportunity.
+   * An expired backoff marker represents a half-open endpoint until a foreground
+   * request acquires and resolves its recovery lease.
+   */
+  private isRpcDiagnosticEligible(rpcUrl: string): boolean {
+    const state = this.rpcHealthStates.get(rpcUrl);
+    return state?.temporaryUnavailableUntil === undefined &&
+      state?.recoveryProbeToken === undefined &&
+      this.circuitBreaker.getState(rpcUrl) === "closed";
+  }
+
+  /**
    * Acquires the single half-open probe permitted for an endpoint after backoff.
    */
   private acquireRpcAttempt(rpcUrl: string): RpcAttemptLease | null {
     const state = this.getHealthState(rpcUrl);
     const backoffUntil = state.temporaryUnavailableUntil;
 
-    // The expired backoff marker is consumed when a recovery probe begins, so
-    // this guard must be independent of that marker while the probe is active.
-    if (state.recoveryProbeInFlight) {
+    if (state.recoveryProbeToken) {
       return null;
     }
 
@@ -575,59 +608,64 @@ export class Permit2RpcManager {
     // A completed backoff window is half-open: exactly one request may test
     // the endpoint, regardless of how many failures started that backoff.
     if (typeof backoffUntil === "number" && backoffUntil > 0) {
-      state.recoveryProbeInFlight = true;
-      state.temporaryUnavailableUntil = undefined;
+      const token = `${this.recoveryLeaseOwner}:${++this.recoveryLeaseSequence}`;
+      state.recoveryProbeToken = token;
       this._log("debug", `[HEALTH] Admitting recovery probe for ${getRpcEndpointId(rpcUrl)}`);
-      return { recoveryProbe: true };
+      return { kind: "recovery", token, expiredBackoffUntil: backoffUntil };
     }
 
-    return { recoveryProbe: false };
+    return { kind: "normal" };
   }
 
-  private releaseRpcAttempt(rpcUrl: string, lease: RpcAttemptLease): void {
-    if (!lease.recoveryProbe) return;
+  private releaseRpcAttempt(
+    rpcUrl: string,
+    lease: RpcAttemptLease,
+    outcome: "completed" | "cancelled" = "completed",
+  ): void {
+    if (lease.kind !== "recovery" || !lease.token) return;
 
     const state = this.getHealthState(rpcUrl);
-    state.recoveryProbeInFlight = false;
+    // A stale lease must never modify a newer recovery window.
+    if (state.recoveryProbeToken !== lease.token) return;
+
+    state.recoveryProbeToken = undefined;
+
+    if (outcome === "cancelled") {
+      // Keep the expired marker intact so a foreground request can retry the
+      // half-open probe. A failure may have opened a fresh backoff meanwhile.
+      return;
+    }
+
+    // A completed probe consumes only the exact expired window it acquired. A
+    // success clears the marker and a failed probe installs a newer backoff.
+    if (state.temporaryUnavailableUntil === lease.expiredBackoffUntil) {
+      state.temporaryUnavailableUntil = undefined;
+    }
   }
 
   /**
    * Record a successful RPC call
    */
-  private async recordSuccess(chainId: number, rpcUrl: string): Promise<void> {
+  private recordSuccess(rpcUrl: string): void {
     const state = this.getHealthState(rpcUrl);
-    const hadFailures = state.lastFailureTime > 0;
 
     state.consecutiveFailures = 0;
     state.lastFailureTime = 0;
     state.lastSuccessTime = Date.now();
     state.temporaryUnavailableUntil = undefined;
-    state.recoveryProbeInFlight = false;
     state.failureReasons.clear();
 
     this._log("debug", `[HEALTH] RPC ${getRpcEndpointId(rpcUrl)} marked healthy`);
-
-    // Update KV if we had failures before
-    if (hadFailures) {
-      try {
-        const kv = await Deno.openKv();
-        const failureKey = ["rpc_failures", chainId, rpcUrl];
-        await kv.delete(failureKey);
-      } catch (error) {
-        this._log("error", `Failed to clear RPC failures in KV:`, error);
-      }
-    }
   }
 
   /**
    * Record a failed RPC call
    */
-  private async recordFailure(chainId: number, rpcUrl: string, classification: ErrorClassification): Promise<void> {
+  private recordFailure(rpcUrl: string, classification: ErrorClassification): void {
     const state = this.getHealthState(rpcUrl);
 
     state.consecutiveFailures++;
     state.lastFailureTime = Date.now();
-    state.recoveryProbeInFlight = false;
 
     // Track failure reasons
     const count = state.failureReasons.get(classification.reason) || 0;
@@ -658,20 +696,6 @@ export class Permit2RpcManager {
               .join(", ")
           }`,
       );
-    }
-
-    // Persist to KV for recovery after restart
-    try {
-      const kv = await Deno.openKv();
-      const failureKey = ["rpc_failures", chainId, rpcUrl];
-      await kv.set(failureKey, {
-        consecutiveFailures: state.consecutiveFailures,
-        lastFailureTime: state.lastFailureTime,
-        failureReasons: Object.fromEntries(state.failureReasons),
-        temporaryUnavailableUntil: state.temporaryUnavailableUntil,
-      });
-    } catch (error) {
-      this._log("error", `Failed to persist RPC failure to KV:`, error);
     }
   }
 
@@ -716,6 +740,90 @@ export class Permit2RpcManager {
     });
   }
 
+  private isHedgeCancellation(signal: AbortSignal | undefined): boolean {
+    return Boolean(signal?.aborted && signal.reason === HEDGE_ABORT_REASON);
+  }
+
+  private isNonRetryableError(error: Error): boolean {
+    const classification = this.classifyError(error);
+    return classification.behavior === ErrorBehavior.DO_NOT_RETRY ||
+      classification.behavior === ErrorBehavior.BLOCKCHAIN_ERROR;
+  }
+
+  /**
+   * Execute one already-admitted candidate. Every execution mode goes through
+   * this method so capability, health, scorer, throttle, circuit, and metrics
+   * accounting cannot drift apart.
+   */
+  private async executeCandidate<T>(
+    chainId: number,
+    method: string,
+    params: unknown[],
+    rpcUrl: string,
+    lease: RpcAttemptLease,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<T> {
+    let releaseOutcome: "completed" | "cancelled" = "completed";
+    const startTime = Date.now();
+
+    try {
+      const result = await this.executeRpcCall<T>(rpcUrl, method, params, options);
+
+      // A losing hedge can resolve despite aborting its fetch. It never becomes
+      // a success signal or consumes a half-open recovery window.
+      if (this.isHedgeCancellation(options.signal)) {
+        releaseOutcome = "cancelled";
+        throw new Error("Hedged request cancelled");
+      }
+
+      const responseTime = Date.now() - startTime;
+      this.recordSuccess(rpcUrl);
+      this.rpcMethodCapabilities.markSupported(chainId, rpcUrl, method);
+      this.rpcMetrics.recordSuccess({ chainId, rpcUrl, method }, responseTime);
+      this.rpcScorer.updateScore(rpcUrl, true, responseTime);
+      this.circuitBreaker.recordResult(rpcUrl, undefined, true);
+      this.adaptiveTimeout.recordResponseTime(rpcUrl, responseTime);
+
+      return result;
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+
+      if (this.isHedgeCancellation(options.signal)) {
+        releaseOutcome = "cancelled";
+        throw err;
+      }
+
+      const classification = this.classifyError(err);
+      if (classification.methodUnsupported) {
+        this.rpcMethodCapabilities.markUnsupported(chainId, rpcUrl, method, err.message, this.capabilityTtlMs);
+      }
+
+      this._log(
+        "warn",
+        `[SEND] RPC ${getRpcEndpointId(rpcUrl)} failed: ${classification.reason} ` +
+          `(behavior: ${ErrorBehavior[classification.behavior]})`,
+      );
+
+      if (
+        classification.behavior === ErrorBehavior.DO_NOT_RETRY ||
+        classification.behavior === ErrorBehavior.BLOCKCHAIN_ERROR ||
+        classification.methodUnsupported
+      ) {
+        // Request-deterministic errors and endpoint-method capability misses
+        // must not degrade the endpoint or any of its method-independent scores.
+        throw err;
+      }
+
+      this.rpcMetrics.recordFailure({ chainId, rpcUrl, method }, classification);
+      this.recordFailure(rpcUrl, classification);
+      this.rpcScorer.updateScore(rpcUrl, false);
+      this.circuitBreaker.recordResult(rpcUrl, classification, false);
+      throw err;
+    } finally {
+      this.releaseRpcAttempt(rpcUrl, lease, releaseOutcome);
+    }
+  }
+
   /**
    * Internal send implementation (after deduplication)
    */
@@ -740,7 +848,8 @@ export class Permit2RpcManager {
 
     if (this.headSampling.enabled) {
       try {
-        await this.headTracker.maybeSampleHeads(chainId, availableRpcs);
+        const diagnosticRpcs = availableRpcs.filter((rpcUrl) => this.isRpcDiagnosticEligible(rpcUrl));
+        await this.headTracker.maybeSampleHeads(chainId, diagnosticRpcs);
       } catch (error) {
         this._log("debug", `[HEAD] Head sampling failed for chain ${chainId}`, error);
       }
@@ -881,68 +990,46 @@ export class Permit2RpcManager {
       this.consensus.methods.includes(normalizedMethod) && orderedRpcs.length > 1;
 
     if (consensusEnabled) {
+      const participantTarget = Math.min(Math.max(1, this.consensus.participants), orderedRpcs.length);
+      const preAcquiredLeases = new Map<string, RpcAttemptLease>();
+
+      // Scan beyond a busy half-open endpoint so consensus has as many
+      // participants as configured without violating its recovery lease.
+      for (const rpcUrl of orderedRpcs) {
+        const lease = this.acquireRpcAttempt(rpcUrl);
+        if (!lease) continue;
+        preAcquiredLeases.set(rpcUrl, lease);
+        if (preAcquiredLeases.size >= participantTarget) break;
+      }
+
+      if (preAcquiredLeases.size === 0) {
+        throw this.allRpcsFailedError(chainId, attemptedRpcs, lastError);
+      }
+
+      const consensusParticipants = [...preAcquiredLeases.keys()];
+      const usedParticipants = new Set<string>();
       try {
         return await this.consensusExecutor.execute<T>(
           chainId,
           method,
-          orderedRpcs,
+          consensusParticipants,
           async (rpcUrl) => {
-            const attemptLease = this.acquireRpcAttempt(rpcUrl);
-            if (!attemptLease) {
-              throw new RpcAttemptUnavailableError();
-            }
+            const attemptLease = preAcquiredLeases.get(rpcUrl);
+            if (!attemptLease) throw new RpcAttemptUnavailableError();
 
+            usedParticipants.add(rpcUrl);
             attemptedRpcs.push(rpcUrl);
-            this._log("info", `[SEND] (consensus) Trying ${rpcUrl} for ${method} on chain ${chainId}`);
-
-            const startTime = Date.now();
             try {
-              const result = await this.executeRpcCall<T>(rpcUrl, method, params);
-              const responseTime = Date.now() - startTime;
-
-              await this.recordSuccess(chainId, rpcUrl);
-              this.rpcMetrics.recordSuccess({ chainId, rpcUrl, method }, responseTime);
-              this.rpcScorer.updateScore(rpcUrl, true, responseTime);
-              this.circuitBreaker.recordResult(rpcUrl, undefined, true);
-              this.adaptiveTimeout.recordResponseTime(rpcUrl, responseTime);
-
-              return result;
+              this._log(
+                "info",
+                `[SEND] (consensus) Trying ${getRpcEndpointId(rpcUrl)} for ${method} on chain ${chainId}`,
+              );
+              return await this.executeCandidate<T>(chainId, method, params, rpcUrl, attemptLease);
             } catch (error) {
               const err = error instanceof Error ? error : new Error(String(error));
               lastError = err;
-
-              if (err instanceof JsonRpcError && err.code === JSON_RPC_ERROR_CODES.METHOD_NOT_FOUND) {
-                this.rpcMethodCapabilities.markUnsupported(chainId, rpcUrl, method, err.message, this.capabilityTtlMs);
-              }
-
-              const classification = this.classifyError(err);
-              const circuitClassification = classification.reason === "method_not_found"
-                ? { ...classification, isProviderIssue: false }
-                : classification;
-
-              this._log(
-                "warn",
-                `[SEND] RPC ${rpcUrl} failed: ${classification.reason} ` +
-                  `(behavior: ${ErrorBehavior[classification.behavior]})`,
-              );
-
-              if (
-                classification.behavior === ErrorBehavior.DO_NOT_RETRY ||
-                classification.behavior === ErrorBehavior.BLOCKCHAIN_ERROR
-              ) {
-                this.circuitBreaker.recordResult(rpcUrl, circuitClassification, false);
-                throw err;
-              }
-
-              this.rpcMetrics.recordFailure({ chainId, rpcUrl, method }, classification);
-              if (classification.reason !== "method_not_found") {
-                await this.recordFailure(chainId, rpcUrl, classification);
-                this.rpcScorer.updateScore(rpcUrl, false);
-              }
-              this.circuitBreaker.recordResult(rpcUrl, circuitClassification, false);
+              if (this.isNonRetryableError(err)) throw new ConsensusNonRetryableError(err);
               throw err;
-            } finally {
-              this.releaseRpcAttempt(rpcUrl, attemptLease);
             }
           },
           this.consensus,
@@ -959,6 +1046,12 @@ export class Permit2RpcManager {
         }
 
         throw this.allRpcsFailedError(chainId, attemptedRpcs, lastError ?? err);
+      } finally {
+        for (const [rpcUrl, lease] of preAcquiredLeases) {
+          if (!usedParticipants.has(rpcUrl)) {
+            this.releaseRpcAttempt(rpcUrl, lease, "cancelled");
+          }
+        }
       }
     }
 
@@ -994,72 +1087,20 @@ export class Permit2RpcManager {
           orderedRpcs,
           async (rpcUrl, signal) => {
             const attemptLease = this.acquireRpcAttempt(rpcUrl);
-            if (!attemptLease) {
-              throw new RpcAttemptUnavailableError();
-            }
+            if (!attemptLease) throw new RpcAttemptUnavailableError();
 
             attemptedRpcs.push(rpcUrl);
-            this._log("info", `[SEND] (hedged) Trying ${rpcUrl} for ${method} on chain ${chainId}`);
-
-            const startTime = Date.now();
             try {
-              const result = await this.executeRpcCall<T>(rpcUrl, method, params, { signal });
-              const responseTime = Date.now() - startTime;
-
-              await this.recordSuccess(chainId, rpcUrl);
-              this.rpcMetrics.recordSuccess({ chainId, rpcUrl, method }, responseTime);
-              this.rpcScorer.updateScore(rpcUrl, true, responseTime);
-              this.circuitBreaker.recordResult(rpcUrl, undefined, true);
-              this.adaptiveTimeout.recordResponseTime(rpcUrl, responseTime);
-
-              return result;
+              this._log(
+                "info",
+                `[SEND] (hedged) Trying ${getRpcEndpointId(rpcUrl)} for ${method} on chain ${chainId}`,
+              );
+              return await this.executeCandidate<T>(chainId, method, params, rpcUrl, attemptLease, { signal });
             } catch (error) {
               const err = error instanceof Error ? error : new Error(String(error));
-
-              if (signal.aborted && signal.reason === HEDGE_ABORT_REASON) {
-                throw err;
-              }
-
-              lastError = err;
-
-              if (err instanceof JsonRpcError && err.code === JSON_RPC_ERROR_CODES.METHOD_NOT_FOUND) {
-                this.rpcMethodCapabilities.markUnsupported(chainId, rpcUrl, method, err.message, this.capabilityTtlMs);
-              }
-
-              const classification = this.classifyError(err);
-              const circuitClassification = classification.reason === "method_not_found"
-                ? { ...classification, isProviderIssue: false }
-                : classification;
-
-              this._log(
-                "warn",
-                `[SEND] RPC ${rpcUrl} failed: ${classification.reason} ` +
-                  `(behavior: ${ErrorBehavior[classification.behavior]})`,
-              );
-
-              if (
-                classification.behavior === ErrorBehavior.DO_NOT_RETRY ||
-                classification.behavior === ErrorBehavior.BLOCKCHAIN_ERROR
-              ) {
-                this.circuitBreaker.recordResult(rpcUrl, circuitClassification, false);
-                this._log(
-                  "info",
-                  `[SEND] Error type ${ErrorBehavior[classification.behavior]} detected. ` +
-                    `Not recording as RPC failure to prevent cascade.`,
-                );
-                throw new HedgedNonRetryableError(err);
-              }
-
-              this.rpcMetrics.recordFailure({ chainId, rpcUrl, method }, classification);
-              if (classification.reason !== "method_not_found") {
-                await this.recordFailure(chainId, rpcUrl, classification);
-                this.rpcScorer.updateScore(rpcUrl, false);
-              }
-              this.circuitBreaker.recordResult(rpcUrl, circuitClassification, false);
-
+              if (!this.isHedgeCancellation(signal)) lastError = err;
+              if (this.isNonRetryableError(err)) throw new HedgedNonRetryableError(err);
               throw err;
-            } finally {
-              this.releaseRpcAttempt(rpcUrl, attemptLease);
             }
           },
           { maxHedges: this.hedgeConfig.maxHedges, delayMs: hedgeDelayMs },
@@ -1088,67 +1129,12 @@ export class Permit2RpcManager {
       attemptedRpcs.push(rpcUrl);
 
       try {
-        this._log("info", `[SEND] Trying ${rpcUrl} for ${method} on chain ${chainId}`);
-
-        const startTime = Date.now();
-        const result = await this.executeRpcCall<T>(rpcUrl, method, params);
-        const responseTime = Date.now() - startTime;
-
-        // Record success metrics
-        await this.recordSuccess(chainId, rpcUrl);
-        this.rpcMetrics.recordSuccess({ chainId, rpcUrl, method }, responseTime);
-        this.rpcScorer.updateScore(rpcUrl, true, responseTime);
-        this.circuitBreaker.recordResult(rpcUrl, undefined, true);
-        this.adaptiveTimeout.recordResponseTime(rpcUrl, responseTime);
-
-        return result;
+        this._log("info", `[SEND] Trying ${getRpcEndpointId(rpcUrl)} for ${method} on chain ${chainId}`);
+        return await this.executeCandidate<T>(chainId, method, params, rpcUrl, attemptLease);
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
-
-        if (lastError instanceof JsonRpcError && lastError.code === JSON_RPC_ERROR_CODES.METHOD_NOT_FOUND) {
-          this.rpcMethodCapabilities.markUnsupported(chainId, rpcUrl, method, lastError.message, this.capabilityTtlMs);
-        }
-
-        // Classify the error
-        const classification = this.classifyError(lastError);
-        const circuitClassification = classification.reason === "method_not_found"
-          ? { ...classification, isProviderIssue: false }
-          : classification;
-
-        this._log(
-          "warn",
-          `[SEND] RPC ${rpcUrl} failed: ${classification.reason} ` +
-            `(behavior: ${ErrorBehavior[classification.behavior]})`,
-        );
-
-        // Decide if we should continue trying other RPCs
-        switch (classification.behavior) {
-          case ErrorBehavior.DO_NOT_RETRY:
-          case ErrorBehavior.BLOCKCHAIN_ERROR:
-            this.circuitBreaker.recordResult(rpcUrl, circuitClassification, false);
-            // These are client/request errors that will be the same on all RPCs
-            // Don't record as failures to prevent cascading health issues
-            this._log(
-              "info",
-              `[SEND] Error type ${ErrorBehavior[classification.behavior]} detected. ` +
-                `Not recording as RPC failure to prevent cascade.`,
-            );
-            throw lastError;
-
-          case ErrorBehavior.RETRY_WITH_BACKOFF:
-          case ErrorBehavior.RETRY_DIFFERENT_RPC:
-            this.rpcMetrics.recordFailure({ chainId, rpcUrl, method }, classification);
-            if (classification.reason !== "method_not_found") {
-              // These are RPC-specific issues that should count toward health
-              await this.recordFailure(chainId, rpcUrl, classification);
-              this.rpcScorer.updateScore(rpcUrl, false);
-            }
-            this.circuitBreaker.recordResult(rpcUrl, circuitClassification, false);
-            // Continue to next RPC
-            continue;
-        }
-      } finally {
-        this.releaseRpcAttempt(rpcUrl, attemptLease);
+        if (this.isNonRetryableError(lastError)) throw lastError;
+        continue;
       }
     }
 
@@ -1206,20 +1192,28 @@ export class Permit2RpcManager {
       if (externalSignal) externalSignal.removeEventListener("abort", abortListener);
 
       // Parse response regardless of HTTP status
-      let responseData: any;
+      let responseData: unknown;
       try {
         responseData = await response.json();
       } catch (_jsonError) {
         throw new InvalidJsonResponseError(response.status);
       }
 
-      // Check for JSON-RPC error
-      if (responseData.error) {
+      if (!isJsonRpcResponseEnvelope(responseData)) {
+        throw new InvalidJsonResponseError(response.status);
+      }
+
+      // Only an actual decoded JSON-RPC error gets semantic precedence over an
+      // HTTP wrapper. Synthesized transport/invalid-body errors do not.
+      if (hasOwn(responseData, "error") && isJsonRpcErrorObject(responseData.error)) {
+        const errorCode = responseData.error.code;
+        const errorMessage = responseData.error.message;
         throw new JsonRpcError(
-          responseData.error.code || JSON_RPC_ERROR_CODES.INTERNAL_ERROR,
-          responseData.error.message || "RPC error",
+          errorCode,
+          errorMessage,
           responseData.error.data,
           response.status,
+          "provider_jsonrpc",
         );
       }
 
@@ -1230,6 +1224,7 @@ export class Permit2RpcManager {
           `HTTP error ${response.status} ${response.statusText}`,
           undefined,
           response.status,
+          "transport",
         );
       }
 
@@ -1276,7 +1271,7 @@ export class Permit2RpcManager {
    * Emergency fallback: Reset all RPC health states for a given chain
    * This is called when no healthy RPCs are available to prevent permanent failures
    */
-  private async resetAllRpcHealthStates(chainId: number, rpcUrls: string[]): Promise<void> {
+  private resetAllRpcHealthStates(chainId: number, rpcUrls: string[]): void {
     this._log("warn", `[HEALTH RESET] Resetting health states for ${rpcUrls.length} RPCs on chain ${chainId}`);
 
     for (const rpcUrl of rpcUrls) {
@@ -1289,20 +1284,8 @@ export class Permit2RpcManager {
         lastFailureTime: -1,
         lastSuccessTime: Date.now(),
         temporaryUnavailableUntil: undefined,
-        recoveryProbeInFlight: false,
         failureReasons: new Map(),
       });
-
-      // Also clear from KV store to prevent persistence of bad state
-      try {
-        const kv = await Deno.openKv();
-        const failureKey = ["rpc_failures", chainId, rpcUrl];
-        await kv.delete(failureKey);
-
-        this._log("debug", `[HEALTH RESET] Cleared KV state for ${getRpcEndpointId(rpcUrl)}`);
-      } catch (error) {
-        this._log("error", `[HEALTH RESET] Failed to clear KV state for ${getRpcEndpointId(rpcUrl)}:`, error);
-      }
     }
 
     this._log("info", `[HEALTH RESET] Successfully reset health states for all RPCs on chain ${chainId}`);
@@ -1372,7 +1355,7 @@ export class Permit2RpcManager {
             rpcInfo.consecutiveFailures = healthState.consecutiveFailures;
             rpcInfo.lastFailureTime = healthState.lastFailureTime > 0 ? healthState.lastFailureTime : null;
             rpcInfo.lastSuccessTime = healthState.lastSuccessTime > 0 ? healthState.lastSuccessTime : null;
-            rpcInfo.recoveryProbeInFlight = Boolean(healthState.recoveryProbeInFlight);
+            rpcInfo.recoveryProbeInFlight = Boolean(healthState.recoveryProbeToken);
 
             // Check if eliminated
             if (healthState.consecutiveFailures >= this.maxConsecutiveFailures) {

--- a/packages/permit2-rpc-server/src/core/permit2-rpc-manager_capabilities_test.ts
+++ b/packages/permit2-rpc-server/src/core/permit2-rpc-manager_capabilities_test.ts
@@ -36,7 +36,9 @@ Deno.test("METHOD_NOT_FOUND retries another RPC and caches capability", async ()
 
     if (phase === 0) {
       if (url === rpc1) {
-        return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, error: { code: -32601, message: "Method not found" } }));
+        return Promise.resolve(
+          jsonResponse({ jsonrpc: "2.0", id: 1, error: { code: -32601, message: "Method not found" } }),
+        );
       }
       if (url === rpc2) {
         return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "ok-1" }));

--- a/packages/permit2-rpc-server/src/core/permit2-rpc-manager_hardening_test.ts
+++ b/packages/permit2-rpc-server/src/core/permit2-rpc-manager_hardening_test.ts
@@ -60,34 +60,39 @@ function markRpcHalfOpen(manager: Permit2RpcManager, rpcUrl: string): void {
   });
 }
 
-for (const quotaCode of [-32004, -32005]) {
-  Deno.test(`quota code ${quotaCode} fails over to a healthy endpoint`, async () => {
-    const quotaRpc = "https://quota.example";
-    const healthyRpc = "https://healthy.example";
-    const manager = createManager([quotaRpc, healthyRpc]);
-    const restoreOpenKv = installOpenKvMock();
-    const originalFetch = globalThis.fetch;
-    const calls: string[] = [];
+for (const httpStatus of [200, 400, 404]) {
+  for (const quotaCode of [-32004, -32005]) {
+    Deno.test(`quota code ${quotaCode} with HTTP ${httpStatus} fails over to a healthy endpoint`, async () => {
+      const quotaRpc = "https://quota.example";
+      const healthyRpc = "https://healthy.example";
+      const manager = createManager([quotaRpc, healthyRpc]);
+      const restoreOpenKv = installOpenKvMock();
+      const originalFetch = globalThis.fetch;
+      const calls: string[] = [];
 
-    globalThis.fetch = ((input) => {
-      const url = inputUrl(input);
-      calls.push(url);
-      if (url === quotaRpc) {
-        return Promise.resolve(
-          jsonResponse({ jsonrpc: "2.0", id: 1, error: { code: quotaCode, message: "quota exhausted" } }),
-        );
+      globalThis.fetch = ((input) => {
+        const url = inputUrl(input);
+        calls.push(url);
+        if (url === quotaRpc) {
+          return Promise.resolve(
+            jsonResponse(
+              { jsonrpc: "2.0", id: 1, error: { code: quotaCode, message: "quota exhausted" } },
+              { status: httpStatus },
+            ),
+          );
+        }
+        return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "healthy-result" }));
+      }) as typeof fetch;
+
+      try {
+        assert.equal(await manager.send(1, "eth_blockNumber"), "healthy-result");
+        assert.deepEqual(calls, [quotaRpc, healthyRpc]);
+      } finally {
+        globalThis.fetch = originalFetch;
+        restoreOpenKv();
       }
-      return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "healthy-result" }));
-    }) as typeof fetch;
-
-    try {
-      assert.equal(await manager.send(1, "eth_blockNumber"), "healthy-result");
-      assert.deepEqual(calls, [quotaRpc, healthyRpc]);
-    } finally {
-      globalThis.fetch = originalFetch;
-      restoreOpenKv();
-    }
-  });
+    });
+  }
 }
 
 for (const status of [400, 404]) {

--- a/packages/permit2-rpc-server/src/core/permit2-rpc-manager_hardening_test.ts
+++ b/packages/permit2-rpc-server/src/core/permit2-rpc-manager_hardening_test.ts
@@ -32,6 +32,27 @@ function installOpenKvMock(): () => void {
   return () => Object.defineProperty(Deno, "openKv", descriptor);
 }
 
+function installOpenKvSpy(): { calls: () => number; restore: () => void } {
+  const descriptor = Object.getOwnPropertyDescriptor(Deno, "openKv");
+  if (!descriptor) throw new Error("Deno.openKv descriptor is unavailable");
+
+  let callCount = 0;
+  Object.defineProperty(Deno, "openKv", {
+    configurable: descriptor.configurable,
+    enumerable: descriptor.enumerable,
+    writable: true,
+    value: (() => {
+      callCount++;
+      return Promise.resolve({ close: () => {} } as unknown as Deno.Kv);
+    }) as typeof Deno.openKv,
+  });
+
+  return {
+    calls: () => callCount,
+    restore: () => Object.defineProperty(Deno, "openKv", descriptor),
+  };
+}
+
 function createManager(
   rpcs: string[],
   options: ConstructorParameters<typeof Permit2RpcManager>[0] = {},
@@ -55,28 +76,27 @@ function markRpcHalfOpen(manager: Permit2RpcManager, rpcUrl: string): void {
     lastFailureTime: now - 2,
     lastSuccessTime: 0,
     temporaryUnavailableUntil: now - 1,
-    recoveryProbeInFlight: false,
     failureReasons: new Map(),
   });
 }
 
-for (const httpStatus of [200, 400, 404]) {
-  for (const quotaCode of [-32004, -32005]) {
-    Deno.test(`quota code ${quotaCode} with HTTP ${httpStatus} fails over to a healthy endpoint`, async () => {
-      const quotaRpc = "https://quota.example";
+for (const httpStatus of [200, 400, 401, 403, 404, 408, 429, 500]) {
+  for (const capabilityCode of [-32601, -32004]) {
+    Deno.test(`method capability code ${capabilityCode} with HTTP ${httpStatus} fails over without endpoint penalties`, async () => {
+      const unsupportedRpc = "https://unsupported.example";
       const healthyRpc = "https://healthy.example";
-      const manager = createManager([quotaRpc, healthyRpc]);
-      const restoreOpenKv = installOpenKvMock();
+      const method = "debug_traceCall";
+      const manager = createManager([unsupportedRpc, healthyRpc]);
       const originalFetch = globalThis.fetch;
       const calls: string[] = [];
 
       globalThis.fetch = ((input) => {
         const url = inputUrl(input);
         calls.push(url);
-        if (url === quotaRpc) {
+        if (url === unsupportedRpc) {
           return Promise.resolve(
             jsonResponse(
-              { jsonrpc: "2.0", id: 1, error: { code: quotaCode, message: "quota exhausted" } },
+              { jsonrpc: "2.0", id: 1, error: { code: capabilityCode, message: "method unsupported" } },
               { status: httpStatus },
             ),
           );
@@ -85,17 +105,56 @@ for (const httpStatus of [200, 400, 404]) {
       }) as typeof fetch;
 
       try {
-        assert.equal(await manager.send(1, "eth_blockNumber"), "healthy-result");
-        assert.deepEqual(calls, [quotaRpc, healthyRpc]);
+        assert.equal(await manager.send(1, method), "healthy-result");
+        assert.deepEqual(calls, [unsupportedRpc, healthyRpc]);
+        assert.equal((manager as any).rpcMethodCapabilities.get(1, unsupportedRpc, method), "unsupported");
+        assert.equal((manager as any).rpcHealthStates.get(unsupportedRpc).consecutiveFailures, 0);
+        assert.equal((manager as any).circuitBreaker.getState(unsupportedRpc), "closed");
+        const stats = (manager as any).rpcMetrics.getMethodStats(1, method, [unsupportedRpc]).get(unsupportedRpc);
+        assert.equal(stats.requestsTotal, 0);
+        assert.equal(stats.throttleRate, undefined);
       } finally {
         globalThis.fetch = originalFetch;
-        restoreOpenKv();
       }
     });
   }
+
+  Deno.test(`limit-exceeded code -32005 with HTTP ${httpStatus} fails over and opens backoff`, async () => {
+    const limitedRpc = "https://limited.example";
+    const healthyRpc = "https://healthy.example";
+    const manager = createManager([limitedRpc, healthyRpc]);
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+
+    globalThis.fetch = ((input) => {
+      const url = inputUrl(input);
+      calls.push(url);
+      if (url === limitedRpc) {
+        return Promise.resolve(
+          jsonResponse(
+            { jsonrpc: "2.0", id: 1, error: { code: -32005, message: "limit exceeded" } },
+            { status: httpStatus },
+          ),
+        );
+      }
+      return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "healthy-result" }));
+    }) as typeof fetch;
+
+    try {
+      assert.equal(await manager.send(1, "eth_blockNumber"), "healthy-result");
+      assert.deepEqual(calls, [limitedRpc, healthyRpc]);
+      const healthState = (manager as any).rpcHealthStates.get(limitedRpc);
+      assert.equal(healthState.consecutiveFailures, 1);
+      assert.ok(healthState.temporaryUnavailableUntil > Date.now());
+      const stats = (manager as any).rpcMetrics.getMethodStats(1, "eth_blockNumber", [limitedRpc]).get(limitedRpc);
+      assert.equal(stats.throttleRate, 1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 }
 
-for (const status of [400, 404]) {
+for (const status of [400, 404, 429]) {
   Deno.test(`non-JSON ${status} provider responses fail over`, async () => {
     const invalidJsonRpc = "https://invalid-json.example";
     const healthyRpc = "https://healthy-json.example";
@@ -116,6 +175,9 @@ for (const status of [400, 404]) {
     try {
       assert.equal(await manager.send(1, "eth_blockNumber"), "healthy-result");
       assert.deepEqual(calls, [invalidJsonRpc, healthyRpc]);
+      if (status === 429) {
+        assert.ok((manager as any).rpcHealthStates.get(invalidJsonRpc).temporaryUnavailableUntil > Date.now());
+      }
     } finally {
       globalThis.fetch = originalFetch;
       restoreOpenKv();
@@ -148,7 +210,59 @@ Deno.test("JSON-RPC parse errors returned by a provider preserve client-error ha
   }
 });
 
-Deno.test("invalid params and deterministic execution errors do not retry", async () => {
+Deno.test("unknown decoded provider codes fall back to their HTTP wrapper", async () => {
+  const unknownRpc = "https://unknown-code.example";
+  const healthyRpc = "https://healthy-code.example";
+  const manager = createManager([unknownRpc, healthyRpc]);
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = ((input) => {
+    if (inputUrl(input) === unknownRpc) {
+      return Promise.resolve(
+        jsonResponse(
+          { jsonrpc: "2.0", id: 1, error: { code: -32099, message: "unknown provider code" } },
+          { status: 429 },
+        ),
+      );
+    }
+    return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "healthy-result" }));
+  }) as typeof fetch;
+
+  try {
+    assert.equal(await manager.send(1, "eth_blockNumber"), "healthy-result");
+    assert.ok((manager as any).rpcHealthStates.get(unknownRpc).temporaryUnavailableUntil > Date.now());
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("JSON-parsable non-JSON-RPC response bodies fail over instead of succeeding with undefined", async () => {
+  const malformedRpc = "https://malformed-envelope.example";
+  const healthyRpc = "https://healthy-envelope.example";
+  const manager = createManager([malformedRpc, healthyRpc]);
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+
+  globalThis.fetch = ((input) => {
+    const rpcUrl = inputUrl(input);
+    calls.push(rpcUrl);
+    if (rpcUrl === malformedRpc) {
+      return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, unexpected: "body" }));
+    }
+    return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "healthy-result" }));
+  }) as typeof fetch;
+
+  try {
+    assert.equal(await manager.send(1, "eth_blockNumber"), "healthy-result");
+    assert.deepEqual(calls, [malformedRpc, healthyRpc]);
+    assert.equal((manager as any).rpcHealthStates.get(malformedRpc).consecutiveFailures, 1);
+    assert.equal((manager as any).rpcMethodCapabilities.get(1, malformedRpc, "eth_blockNumber"), "unknown");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("invalid params, invalid requests, and deterministic execution errors ignore contradictory HTTP wrappers", async () => {
   const firstRpc = "https://first.example";
   const secondRpc = "https://second.example";
   const manager = createManager([firstRpc, secondRpc]);
@@ -157,21 +271,128 @@ Deno.test("invalid params and deterministic execution errors do not retry", asyn
   try {
     for (
       const error of [
+        { code: -32600, message: "invalid request" },
         { code: -32602, message: "invalid params" },
         { code: 3, message: "execution reverted" },
+        { code: -32000, message: "execution reverted: deterministic contract failure" },
       ]
     ) {
-      const calls: string[] = [];
-      (manager as any).rpcIndexMap.set(1, 0);
-      globalThis.fetch = ((input) => {
-        calls.push(inputUrl(input));
-        return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, error }));
-      }) as typeof fetch;
+      for (const status of [429, 500]) {
+        const calls: string[] = [];
+        (manager as any).rpcIndexMap.set(1, 0);
+        globalThis.fetch = ((input) => {
+          calls.push(inputUrl(input));
+          return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, error }, { status }));
+        }) as typeof fetch;
 
-      await assert.rejects(() => manager.send(1, "eth_call", []));
-      assert.deepEqual(calls, [firstRpc]);
+        await assert.rejects(() => manager.send(1, "eth_call", []));
+        assert.deepEqual(calls, [firstRpc]);
+        assert.equal((manager as any).rpcHealthStates.get(firstRpc).consecutiveFailures, 0);
+      }
     }
   } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("a successful fail-open capability probe clears its stale exclusion", async () => {
+  const rpc = "https://capability-probe.example";
+  const method = "debug_traceCall";
+  const manager = createManager([rpc]);
+  const originalFetch = globalThis.fetch;
+
+  (manager as any).rpcMethodCapabilities.markUnsupported(1, rpc, method, "previous probe", 60_000);
+  globalThis.fetch =
+    (() => Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "supported" }))) as typeof fetch;
+
+  try {
+    assert.equal(await manager.send(1, method), "supported");
+    assert.equal((manager as any).rpcMethodCapabilities.get(1, rpc, method), "unknown");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("health tracking performs no Deno KV operations", async () => {
+  const rpc = "https://no-kv.example";
+  const manager = createManager([rpc]);
+  const originalFetch = globalThis.fetch;
+  const kvSpy = installOpenKvSpy();
+  let phase: "fail" | "succeed" = "fail";
+
+  globalThis.fetch = (() => {
+    if (phase === "fail") {
+      return Promise.resolve(
+        jsonResponse({ jsonrpc: "2.0", id: 1, error: { code: -32005, message: "limit exceeded" } }),
+      );
+    }
+    return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "healthy" }));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(() => manager.send(1, "eth_blockNumber", ["first"]));
+    (manager as any).resetAllRpcHealthStates(1, [rpc]);
+    phase = "succeed";
+    assert.equal(await manager.send(1, "eth_blockNumber", ["second"]), "healthy");
+    assert.equal(kvSpy.calls(), 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    kvSpy.restore();
+  }
+});
+
+Deno.test("a stale recovery lease cannot release a newer lease", () => {
+  const rpc = "https://stale-lease.example";
+  const manager = createManager([rpc]);
+  markRpcHalfOpen(manager, rpc);
+
+  const lease = (manager as any).acquireRpcAttempt(rpc);
+  assert.equal(lease.kind, "recovery");
+  const state = (manager as any).rpcHealthStates.get(rpc);
+  const expiredBackoffUntil = state.temporaryUnavailableUntil;
+  state.recoveryProbeToken = "newer-lease-token";
+
+  (manager as any).releaseRpcAttempt(rpc, lease, "completed");
+
+  assert.equal(state.recoveryProbeToken, "newer-lease-token");
+  assert.equal(state.temporaryUnavailableUntil, expiredBackoffUntil);
+});
+
+Deno.test("recovery leases are exclusive per manager instance, not process-wide", async () => {
+  const rpc = "https://per-instance.example";
+  const first = createManager([rpc]);
+  const second = createManager([rpc]);
+  markRpcHalfOpen(first, rpc);
+  markRpcHalfOpen(second, rpc);
+  const originalFetch = globalThis.fetch;
+  const resolvers: Array<(response: Response) => void> = [];
+  let started = 0;
+  let signalBothStarted!: () => void;
+  const bothStarted = new Promise<void>((resolve) => {
+    signalBothStarted = resolve;
+  });
+
+  globalThis.fetch = (() => {
+    started++;
+    if (started === 2) signalBothStarted();
+    return new Promise<Response>((resolve) => resolvers.push(resolve));
+  }) as typeof fetch;
+
+  try {
+    const firstRequest = first.send<string>(1, "eth_blockNumber", ["first"]);
+    const secondRequest = second.send<string>(1, "eth_blockNumber", ["second"]);
+    await bothStarted;
+    assert.equal(started, 2);
+
+    for (const resolve of resolvers) {
+      resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "ok" }));
+    }
+    assert.equal(await firstRequest, "ok");
+    assert.equal(await secondRequest, "ok");
+  } finally {
+    for (const resolve of resolvers) {
+      resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "ok" }));
+    }
     globalThis.fetch = originalFetch;
   }
 });
@@ -204,7 +425,7 @@ Deno.test("a backed-off endpoint admits one recovery probe and resets after succ
     calls.push(inputUrl(input));
     if (phase === "initial-backoff") {
       return Promise.resolve(
-        jsonResponse({ jsonrpc: "2.0", id: 1, error: { code: -32004, message: "quota exhausted" } }),
+        jsonResponse({ jsonrpc: "2.0", id: 1, error: { code: -32005, message: "limit exceeded" } }),
       );
     }
     if (phase === "recovery") {
@@ -239,7 +460,7 @@ Deno.test("a backed-off endpoint admits one recovery probe and resets after succ
     const healthState = (manager as any).rpcHealthStates.get(rpc);
     assert.equal(healthState.consecutiveFailures, 0);
     assert.equal(healthState.lastFailureTime, 0);
-    assert.equal(healthState.recoveryProbeInFlight, false);
+    assert.equal(healthState.recoveryProbeToken, undefined);
 
     phase = "healthy";
     assert.equal(await manager.send(1, "eth_blockNumber", ["after-recovery"]), "healthy");
@@ -280,7 +501,7 @@ Deno.test("a failed recovery probe consumes its expired backoff window", async (
 
     const healthState = (manager as any).rpcHealthStates.get(rpc);
     assert.equal(healthState.temporaryUnavailableUntil, undefined);
-    assert.equal(healthState.recoveryProbeInFlight, false);
+    assert.equal(healthState.recoveryProbeToken, undefined);
 
     phase = "normal";
     const firstRequest = manager.send<string>(1, "eth_blockNumber", ["first"]);
@@ -366,7 +587,7 @@ Deno.test("consensus requests allow only one half-open recovery probe", async ()
 
     assert.equal(await firstRequest, "ok");
     assert.equal(await secondRequest, "ok");
-    assert.equal((manager as any).rpcHealthStates.get(recoveringRpc).recoveryProbeInFlight, false);
+    assert.equal((manager as any).rpcHealthStates.get(recoveringRpc).recoveryProbeToken, undefined);
   } finally {
     for (const resolve of recoveryResolvers) {
       resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "ok" }));
@@ -434,7 +655,7 @@ Deno.test("hedged requests allow only one half-open recovery probe", async () =>
       resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "healthy" }));
     }
     assert.equal(await secondRequest, "healthy");
-    assert.equal((manager as any).rpcHealthStates.get(recoveringRpc).recoveryProbeInFlight, false);
+    assert.equal((manager as any).rpcHealthStates.get(recoveringRpc).recoveryProbeToken, undefined);
   } finally {
     for (const resolve of recoveryResolvers) {
       resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "recovered" }));
@@ -444,6 +665,124 @@ Deno.test("hedged requests allow only one half-open recovery probe", async () =>
     }
     globalThis.fetch = originalFetch;
     restoreOpenKv();
+  }
+});
+
+Deno.test("a cancelled hedge restores half-open eligibility for a foreground recovery", async () => {
+  const recoveringRpc = "https://cancelled-recovery.example";
+  const healthyRpc = "https://cancelled-healthy.example";
+  const manager = createManager([recoveringRpc, healthyRpc], {
+    hedge: { enabled: true, maxHedges: 1, delayMs: 0, minDelayMs: 0, maxDelayMs: 0 },
+  });
+  markRpcHalfOpen(manager, recoveringRpc);
+  const expiredBackoffUntil = (manager as any).rpcHealthStates.get(recoveringRpc).temporaryUnavailableUntil;
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = ((input, init) => {
+    const rpcUrl = inputUrl(input);
+    if (rpcUrl === recoveringRpc) {
+      const signal = init?.signal;
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+      });
+    }
+    return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "healthy" }));
+  }) as typeof fetch;
+
+  try {
+    assert.equal(await manager.send(1, "eth_chainId", ["hedged"]), "healthy");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const state = (manager as any).rpcHealthStates.get(recoveringRpc);
+    assert.equal(state.recoveryProbeToken, undefined);
+    assert.equal(state.temporaryUnavailableUntil, expiredBackoffUntil);
+
+    (manager as any).rpcIndexMap.set(1, 0);
+    globalThis.fetch = ((input) => {
+      assert.equal(inputUrl(input), recoveringRpc);
+      return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "recovered" }));
+    }) as typeof fetch;
+    assert.equal(
+      await manager.send(1, "eth_chainId", ["foreground"], { rpcOverrides: [recoveringRpc], allowFallback: false }),
+      "recovered",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("consensus pre-acquires later candidates when an earlier recovery lease is busy", async () => {
+  const busyRpc = "https://consensus-busy.example";
+  const firstRpc = "https://consensus-first.example";
+  const secondRpc = "https://consensus-second.example";
+  const manager = createManager([busyRpc, firstRpc, secondRpc], {
+    consensus: {
+      enabled: true,
+      methods: ["eth_blockNumber"],
+      participants: 2,
+      agreementThreshold: 1,
+    },
+  });
+  markRpcHalfOpen(manager, busyRpc);
+  (manager as any).rpcHealthStates.get(busyRpc).recoveryProbeToken = "already-probing";
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+
+  globalThis.fetch = ((input) => {
+    calls.push(inputUrl(input));
+    return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: 1, result: "0x1" }));
+  }) as typeof fetch;
+
+  try {
+    assert.equal(await manager.send(1, "eth_blockNumber"), "0x1");
+    assert.equal(calls.includes(busyRpc), false);
+    assert.deepEqual(new Set(calls), new Set([firstRpc, secondRpc]));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("head sampling excludes backed-off, half-open, and actively probed endpoints", async () => {
+  const backedOffRpc = "https://head-backed-off.example";
+  const recoveringRpc = "https://head-recovering.example";
+  const activeProbeRpc = "https://head-active-probe.example";
+  const healthyRpc = "https://head-healthy.example";
+  const manager = createManager([backedOffRpc, recoveringRpc, activeProbeRpc, healthyRpc], {
+    headSampling: { enabled: true, sampleIntervalMs: 0, maxRpcsPerSample: 4 },
+  });
+  const now = Date.now();
+  (manager as any).rpcHealthStates.set(backedOffRpc, {
+    consecutiveFailures: 1,
+    lastFailureTime: now - 1,
+    lastSuccessTime: 0,
+    temporaryUnavailableUntil: now + 60_000,
+    failureReasons: new Map(),
+  });
+  markRpcHalfOpen(manager, recoveringRpc);
+  markRpcHalfOpen(manager, activeProbeRpc);
+  (manager as any).rpcHealthStates.get(activeProbeRpc).recoveryProbeToken = "active-probe";
+  const originalFetch = globalThis.fetch;
+  const headSampleUrls: string[] = [];
+
+  globalThis.fetch = ((input, init) => {
+    const request = JSON.parse(String(init?.body)) as { id?: unknown; method?: string };
+    if (
+      request.method === "eth_blockNumber" && typeof request.id === "string" && request.id.startsWith("head-tracker-")
+    ) {
+      headSampleUrls.push(inputUrl(input));
+      return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: request.id, result: "0x10" }));
+    }
+    return Promise.resolve(jsonResponse({ jsonrpc: "2.0", id: request.id, result: "0x1" }));
+  }) as typeof fetch;
+
+  try {
+    assert.equal(
+      await manager.send(1, "eth_chainId", [], { rpcOverrides: [healthyRpc], allowFallback: false }),
+      "0x1",
+    );
+    assert.deepEqual(headSampleUrls, [healthyRpc]);
+  } finally {
+    globalThis.fetch = originalFetch;
   }
 });
 

--- a/packages/permit2-rpc-server/src/core/rpc-endpoint-id.test.ts
+++ b/packages/permit2-rpc-server/src/core/rpc-endpoint-id.test.ts
@@ -31,6 +31,40 @@ Deno.test("RPC endpoint diagnostics preserve trailing punctuation outside URL id
   assertEquals(redactRpcDiagnostic(`failed (${endpoint}), then retried.`), `failed (${endpointId}), then retried.`);
 });
 
+Deno.test("RPC endpoint diagnostics stop at explicit wrappers and redact compact URL JSON", () => {
+  const quotedEndpoint = "https://user:quoted-secret@quoted.example/rpc?token=quoted-token";
+  const angleEndpoint = "https://user:angle-secret@angle.example/rpc?token=angle-token";
+  const backtickEndpoint = "wss://user:backtick-secret@backtick.example/ws?token=backtick-token";
+  const backslashEndpoint = "https://user:backslash-secret@backslash.example/rpc?token=backslash-token";
+  const firstJsonEndpoint = "https://user:first-secret@first.example/rpc?token=first-token";
+  const secondJsonEndpoint = "https://user:second-secret@second.example/rpc?token=second-token";
+
+  assertEquals(redactRpcDiagnostic(`\"${quotedEndpoint}\"`), `\"${getRpcEndpointId(quotedEndpoint)}\"`);
+  assertEquals(redactRpcDiagnostic(`<${angleEndpoint}>`), `<${getRpcEndpointId(angleEndpoint)}>`);
+  assertEquals(redactRpcDiagnostic(`\`${backtickEndpoint}\``), `\`${getRpcEndpointId(backtickEndpoint)}\``);
+  assertEquals(redactRpcDiagnostic(`\\${backslashEndpoint}\\`), `\\${getRpcEndpointId(backslashEndpoint)}\\`);
+  assertEquals(
+    redactRpcDiagnostic(`{\"first\":\"${firstJsonEndpoint}\",\"second\":\"${secondJsonEndpoint}\"}`),
+    `{\"first\":\"${getRpcEndpointId(firstJsonEndpoint)}\",\"second\":\"${getRpcEndpointId(secondJsonEndpoint)}\"}`,
+  );
+});
+
+Deno.test("RPC endpoint diagnostics preserve legal URL punctuation unless a matching wrapper proves it external", () => {
+  const endpoint = "https://user:secret@rpc.example/v1/path!$&()*+,;=:@?query=one,two!three.";
+  const endpointId = getRpcEndpointId(endpoint);
+
+  assertEquals(redactRpcDiagnostic(endpoint), endpointId);
+  assertEquals(redactRpcDiagnostic(`(${endpoint}),`), `(${endpointId}),`);
+});
+
+Deno.test("RPC endpoint diagnostics preserve IPv6 brackets and semicolon query data", () => {
+  const endpoint = "https://user:pass@[2001:db8::1]:8545/rpc?token=[secret];scope=read";
+  const endpointId = getRpcEndpointId(endpoint);
+
+  assertEquals(redactRpcDiagnostic(endpoint), endpointId);
+  assertEquals(redactRpcDiagnostic(`[${endpoint}]`), `[${endpointId}]`);
+});
+
 Deno.test("RPC endpoint diagnostics redact URL-shaped object keys", () => {
   const endpoint = "https://user:pass@[2001:db8::1]/rpc?token=[secret];scope=read";
   const endpointId = getRpcEndpointId(endpoint);
@@ -47,6 +81,30 @@ Deno.test("RPC endpoint diagnostics redact URL-shaped object keys", () => {
   assertEquals(serialized.includes("secret"), false);
   assertEquals(serialized.includes("scope=read"), false);
   assertEquals(serialized.includes(endpointId), true);
+});
+
+Deno.test("RPC endpoint diagnostics redact poisoned cached health data", () => {
+  const endpoint = "https://user:cache-secret@rpc.example/rpc?token=cache-token";
+  const fallbackEndpoint = "https://user:fallback-secret@fallback.example/rpc?token=fallback-token";
+  const diagnostic = redactRpcDiagnostic({
+    cache: {
+      fastestRpc: endpoint,
+      latencyMap: {
+        [endpoint]: {
+          error: `failed <${endpoint}> before trying ${fallbackEndpoint}`,
+          url: endpoint,
+        },
+      },
+    },
+  });
+  const serialized = JSON.stringify(diagnostic);
+
+  assertEquals(serialized.includes("cache-secret"), false);
+  assertEquals(serialized.includes("fallback-secret"), false);
+  assertEquals(serialized.includes("rpc.example"), false);
+  assertEquals(serialized.includes("fallback.example"), false);
+  assertEquals(serialized.includes(getRpcEndpointId(endpoint)), true);
+  assertEquals(serialized.includes(getRpcEndpointId(fallbackEndpoint)), true);
 });
 
 Deno.test("RPC endpoint diagnostic errors expose only redacted fields", () => {

--- a/packages/permit2-rpc-server/src/core/rpc-endpoint-id.ts
+++ b/packages/permit2-rpc-server/src/core/rpc-endpoint-id.ts
@@ -1,50 +1,65 @@
 const FNV_64_OFFSET_BASIS = 0xcbf29ce484222325n;
 const FNV_64_PRIME = 0x100000001b3n;
 const FNV_64_MASK = 0xffffffffffffffffn;
-// URL paths and queries can contain brackets and punctuation, so consume the
-// complete non-whitespace token rather than leaving a sensitive suffix behind.
-const RPC_URL_PATTERN = /(?:https?|wss?):\/\/\S+/gi;
+// Quotes and common diagnostic wrappers terminate URL tokens. Brackets,
+// semicolons, and URL punctuation stay in the token because they are legal
+// URL characters (notably for IPv6 authorities and query strings).
+const RPC_URL_PATTERN = /(?:https?|wss?):\/\/[^\s"'<>`\\]+/gi;
 const MAX_REDACTION_DEPTH = 16;
 const REDACTED_DEPTH_MARKER = "[redacted: maximum depth]";
 const REDACTED_CIRCULAR_MARKER = "[redacted: circular reference]";
+const WRAPPER_CLOSERS: Readonly<Record<string, string>> = {
+  "(": ")",
+  "[": "]",
+  "{": "}",
+};
+const TRAILING_WRAPPER_PUNCTUATION = new Set([",", ".", "!", "?", ";", ":"]);
 
 function normalizeEndpoint(value: string): string {
   return value.trim().replace(/\/$/, "");
 }
 
-function hasUnmatchedClosingDelimiter(value: string, opening: string, closing: string): boolean {
-  let openings = 0;
-  let closings = 0;
-  for (const char of value) {
-    if (char === opening) openings++;
-    if (char === closing) closings++;
+function getExpectedClosingWrappers(value: string, urlOffset: number): string {
+  let expected = "";
+
+  for (let index = urlOffset - 1; index >= 0; index--) {
+    const closing = WRAPPER_CLOSERS[value[index]];
+    if (!closing) break;
+    expected += closing;
   }
-  return closings > openings;
+
+  return expected;
 }
 
-function splitTrailingUrlPunctuation(value: string): { endpoint: string; suffix: string } {
-  let endpointEnd = value.length;
-  let suffix = "";
+function splitTrailingUrlWrappers(
+  matchedUrl: string,
+  diagnostic: string,
+  urlOffset: number,
+): { endpoint: string; suffix: string } {
+  const expectedClosers = getExpectedClosingWrappers(diagnostic, urlOffset);
+  if (!expectedClosers) return { endpoint: matchedUrl, suffix: "" };
 
-  while (endpointEnd > 0) {
-    const char = value[endpointEnd - 1];
-    const candidate = value.slice(0, endpointEnd);
-    const isUnmatchedClosingDelimiter = (char === ")" && hasUnmatchedClosingDelimiter(candidate, "(", ")")) ||
-      (char === "]" && hasUnmatchedClosingDelimiter(candidate, "[", "]")) ||
-      (char === "}" && hasUnmatchedClosingDelimiter(candidate, "{", "}"));
-    const isSentencePunctuation = ",.!?".includes(char);
-    if (!isUnmatchedClosingDelimiter && !isSentencePunctuation) break;
-
-    endpointEnd--;
-    suffix = `${char}${suffix}`;
+  let punctuationStart = matchedUrl.length;
+  while (punctuationStart > 0 && TRAILING_WRAPPER_PUNCTUATION.has(matchedUrl[punctuationStart - 1])) {
+    punctuationStart--;
   }
 
-  return { endpoint: value.slice(0, endpointEnd), suffix };
+  for (let length = Math.min(expectedClosers.length, punctuationStart); length > 0; length--) {
+    if (matchedUrl.slice(punctuationStart - length, punctuationStart) === expectedClosers.slice(0, length)) {
+      const endpointEnd = punctuationStart - length;
+      return {
+        endpoint: matchedUrl.slice(0, endpointEnd),
+        suffix: matchedUrl.slice(endpointEnd),
+      };
+    }
+  }
+
+  return { endpoint: matchedUrl, suffix: "" };
 }
 
 function redactUrlString(value: string): string {
-  return value.replace(RPC_URL_PATTERN, (matchedUrl) => {
-    const { endpoint, suffix } = splitTrailingUrlPunctuation(matchedUrl);
+  return value.replace(RPC_URL_PATTERN, (matchedUrl, urlOffset) => {
+    const { endpoint, suffix } = splitTrailingUrlWrappers(matchedUrl, value, urlOffset);
     return `${getRpcEndpointId(endpoint)}${suffix}`;
   });
 }

--- a/packages/permit2-rpc-server/src/core/rpc-metrics.ts
+++ b/packages/permit2-rpc-server/src/core/rpc-metrics.ts
@@ -77,7 +77,7 @@ function headKey(chainId: number, rpcUrl: string): string {
 
 function isThrottleReason(reason: string | undefined): boolean {
   const normalized = reason?.trim().toLowerCase();
-  return normalized === "rate_limit" || normalized === "quota_exceeded";
+  return normalized === "rate_limit" || normalized === "limit_exceeded";
 }
 
 export class RpcMetricsRegistry implements RpcMetricsProvider {
@@ -163,11 +163,10 @@ export class RpcMetricsRegistry implements RpcMetricsProvider {
 
       const headLagKey = headKey(chainId, rpcUrl);
       const headRecord = this.headLagMetrics.get(headLagKey);
-      const headSorted =
-        headRecord?.lagSamples
-          .toArray()
-          .filter((v) => Number.isFinite(v) && v >= 0)
-          .sort((a, b) => a - b) ?? [];
+      const headSorted = headRecord?.lagSamples
+        .toArray()
+        .filter((v) => Number.isFinite(v) && v >= 0)
+        .sort((a, b) => a - b) ?? [];
       const headLag = median(headSorted);
 
       const errorRate = requestsTotal > 0 ? errors / requestsTotal : undefined;

--- a/packages/permit2-rpc-server/src/core/rpc-metrics_test.ts
+++ b/packages/permit2-rpc-server/src/core/rpc-metrics_test.ts
@@ -25,7 +25,7 @@ Deno.test("RpcMetricsRegistry: records provider failures and separates throttle 
   const method = "eth_getLogs";
 
   metrics.recordFailure({ chainId, rpcUrl, method }, { reason: "network_error", isProviderIssue: true });
-  metrics.recordFailure({ chainId, rpcUrl, method }, { reason: "quota_exceeded", isProviderIssue: true });
+  metrics.recordFailure({ chainId, rpcUrl, method }, { reason: "limit_exceeded", isProviderIssue: true });
   metrics.recordFailure({ chainId, rpcUrl, method }, { reason: "invalid_params", isProviderIssue: false });
 
   const stats = metrics.getMethodStats(chainId, method, [rpcUrl]).get(rpcUrl);

--- a/packages/permit2-rpc-server/src/core/rpc-selector.ts
+++ b/packages/permit2-rpc-server/src/core/rpc-selector.ts
@@ -32,6 +32,7 @@ export class RpcSelector {
     cacheManager: CacheManager,
     latencyTester: LatencyTesterLike,
     logger?: LoggerFn,
+    private readonly isDiagnosticEligible: (url: string) => boolean = () => true,
   ) {
     this.dataSource = dataSource;
     this.cacheManager = cacheManager;
@@ -57,6 +58,8 @@ export class RpcSelector {
     }
 
     const allowedUrls = new Set(rpcUrls);
+    const deferredUrls = new Set(rpcUrls.filter((url) => !this.isDiagnosticEligible(url)));
+    const diagnosticUrls = rpcUrls.filter((url) => !deferredUrls.has(url));
 
     let latencyMap = await this.cacheManager.getLatencyMap(chainId);
     // Use const as this variable is not reassigned before the next block
@@ -82,19 +85,27 @@ export class RpcSelector {
         this.log("info", `No valid cache for chain ${chainId}. Performing latency tests...`);
       }
 
+      if (diagnosticUrls.length === 0) {
+        this.log("debug", `All RPC diagnostics are deferred for chain ${chainId}; retaining cached results.`);
+        // A first request can create a half-open health state before selector
+        // cache data exists. Return the source list so foreground recovery can
+        // still acquire the lease; it will perform its own health filtering.
+        if (!latencyMap) return rpcUrls;
+      }
+
       // --- Latency Test Locking ---
       let testPromise = this.ongoingLatencyTests.get(chainId);
-      if (testPromise) {
+      if (diagnosticUrls.length > 0 && testPromise) {
         this.log("debug", `Latency test already in progress for chain ${chainId}, awaiting result...`);
-        latencyMap = await testPromise; // Wait for the ongoing test
-      } else {
+        latencyMap = this.mergeLatencyMaps(await testPromise, latencyMap, allowedUrls, deferredUrls);
+      } else if (diagnosticUrls.length > 0) {
         // Create the promise, store it, run the test, then remove it
-        testPromise = this.latencyTester.testRpcUrls(chainId, rpcUrls);
+        testPromise = this.latencyTester.testRpcUrls(chainId, diagnosticUrls);
         this.ongoingLatencyTests.set(chainId, testPromise);
         this.log("debug", `Initiated latency test for chain ${chainId}.`);
 
         try {
-          latencyMap = await testPromise;
+          latencyMap = this.mergeLatencyMaps(await testPromise, latencyMap, allowedUrls, deferredUrls);
           // Find the new fastest based on the fresh test results
           const newFastest = this._findFastestInMap(latencyMap);
           await this.cacheManager.updateChainCache(chainId, latencyMap, newFastest?.url ?? null);
@@ -156,6 +167,34 @@ export class RpcSelector {
       }
     }
     return bestResult;
+  }
+
+  /**
+   * Fresh diagnostics replace only the endpoints they were allowed to probe.
+   * Cached entries for health-deferred URLs remain available to foreground
+   * traffic once the manager admits their recovery lease.
+   */
+  private mergeLatencyMaps(
+    freshResults: Record<string, LatencyTestResult>,
+    cachedResults: Record<string, LatencyTestResult> | null,
+    allowedUrls: Set<string>,
+    deferredUrls: Set<string>,
+  ): Record<string, LatencyTestResult> {
+    const merged: Record<string, LatencyTestResult> = {};
+
+    for (const [url, result] of Object.entries(cachedResults ?? {})) {
+      if (allowedUrls.has(url) && deferredUrls.has(url) && result?.url === url) {
+        merged[url] = result;
+      }
+    }
+
+    for (const [url, result] of Object.entries(freshResults)) {
+      if (allowedUrls.has(url) && result?.url === url) {
+        merged[url] = result;
+      }
+    }
+
+    return merged;
   }
 
   /**

--- a/packages/permit2-rpc-server/src/core/rpc-selector_test.ts
+++ b/packages/permit2-rpc-server/src/core/rpc-selector_test.ts
@@ -94,6 +94,90 @@ Deno.test("RpcSelector: ignores cached fastest RPC not in data source", async ()
   assertEquals(ranked, [okRpc]);
 });
 
+Deno.test("RpcSelector: skips deferred diagnostics while retaining cached recovery candidates", async () => {
+  const chainId = 1;
+  const deferredRpc = "https://deferred.example/rpc";
+  const healthyRpc = "https://healthy.example/rpc";
+  const dataSource = { getRpcUrls: () => [deferredRpc, healthyRpc] };
+  const cacheManager = new MemoryCacheManager();
+  const testedUrls: string[][] = [];
+
+  await cacheManager.updateChainCache(
+    chainId,
+    {
+      [deferredRpc]: { url: deferredRpc, latency: 1, status: "ok" },
+      [healthyRpc]: { url: healthyRpc, latency: 20, status: "ok" },
+    },
+    null,
+  );
+
+  const latencyTester = {
+    testRpcUrls: (_chainId: number, urls: string[]): Promise<Record<string, LatencyTestResult>> => {
+      testedUrls.push(urls);
+      return Promise.resolve({ [healthyRpc]: { url: healthyRpc, latency: 10, status: "ok" } });
+    },
+  };
+
+  const selector = new RpcSelector(
+    dataSource,
+    cacheManager,
+    latencyTester,
+    undefined,
+    (url) => url !== deferredRpc,
+  );
+  const ranked = await selector.getRankedRpcList(chainId);
+
+  assertEquals(testedUrls, [[healthyRpc]]);
+  assertEquals(ranked, [deferredRpc, healthyRpc]);
+  const retainedMap = await cacheManager.getLatencyMap(chainId);
+  assertEquals(retainedMap?.[deferredRpc], { url: deferredRpc, latency: 1, status: "ok" });
+});
+
+Deno.test("RpcSelector: excludes backed-off, half-open, and active-probe diagnostics while retaining cached candidates", async () => {
+  const chainId = 1;
+  const backedOffRpc = "https://backed-off.example/rpc";
+  const halfOpenRpc = "https://half-open.example/rpc";
+  const activeProbeRpc = "https://active-probe.example/rpc";
+  const healthyRpc = "https://healthy.example/rpc";
+  const dataSource = { getRpcUrls: () => [backedOffRpc, halfOpenRpc, activeProbeRpc, healthyRpc] };
+  const cacheManager = new MemoryCacheManager();
+  const testedUrls: string[][] = [];
+
+  await cacheManager.updateChainCache(
+    chainId,
+    {
+      [backedOffRpc]: { url: backedOffRpc, latency: 1, status: "ok" },
+      [halfOpenRpc]: { url: halfOpenRpc, latency: 2, status: "ok" },
+      [activeProbeRpc]: { url: activeProbeRpc, latency: 3, status: "ok" },
+      [healthyRpc]: { url: healthyRpc, latency: 20, status: "ok" },
+    },
+    null,
+  );
+
+  const latencyTester = {
+    testRpcUrls: (_chainId: number, urls: string[]): Promise<Record<string, LatencyTestResult>> => {
+      testedUrls.push(urls);
+      return Promise.resolve({ [healthyRpc]: { url: healthyRpc, latency: 10, status: "ok" } });
+    },
+  };
+
+  const selector = new RpcSelector(
+    dataSource,
+    cacheManager,
+    latencyTester,
+    undefined,
+    (url) => url === healthyRpc,
+  );
+  const ranked = await selector.getRankedRpcList(chainId);
+
+  assertEquals(testedUrls, [[healthyRpc]]);
+  assertEquals(ranked, [backedOffRpc, halfOpenRpc, activeProbeRpc, healthyRpc]);
+  const retainedMap = await cacheManager.getLatencyMap(chainId);
+  assertEquals(retainedMap?.[backedOffRpc], { url: backedOffRpc, latency: 1, status: "ok" });
+  assertEquals(retainedMap?.[halfOpenRpc], { url: halfOpenRpc, latency: 2, status: "ok" });
+  assertEquals(retainedMap?.[activeProbeRpc], { url: activeProbeRpc, latency: 3, status: "ok" });
+});
+
 Deno.test("RpcSelector: redacts RPC URLs from selector diagnostics", async () => {
   const chainId = 1;
   const rpcUrl = "https://user:super-secret@rpc.example/rpc?apiKey=very-secret";

--- a/packages/permit2-rpc-server/src/core/types.ts
+++ b/packages/permit2-rpc-server/src/core/types.ts
@@ -1,9 +1,10 @@
-// Simple interface for JSON-RPC request structure
+// JSON-RPC request envelope. Property absence, rather than a null ID, marks a
+// notification; positional params may be omitted and default to an empty list.
 export interface JsonRpcRequest {
   jsonrpc: "2.0";
   method: string;
-  params: unknown[] | Record<string, any>; // Allow both array and object params for MCP
-  id: number | string | null; // Allow null ID for notifications, though we might not process them specially
+  params?: unknown[] | Record<string, unknown>;
+  id?: number | string | null;
 }
 
 // Define the structure for a JSON-RPC response

--- a/packages/permit2-rpc-server/src/deno-server.ts
+++ b/packages/permit2-rpc-server/src/deno-server.ts
@@ -15,25 +15,76 @@ import rpcWhitelist from "../rpc-whitelist.json" with { type: "json" };
 
 export type RequestHandlerManager = Pick<Permit2RpcManager, "getHealthStatus" | "multicall3" | "send">;
 
-// Type guard to check for valid JSON-RPC request object structure
-function isValidJsonRpcRequest(obj: unknown): obj is JsonRpcRequest {
-  if (typeof obj !== "object" || obj === null) {
-    return false;
+type JsonRpcId = JsonRpcResponse["id"];
+
+interface PositionalJsonRpcRequest {
+  jsonrpc: "2.0";
+  method: string;
+  params: unknown[];
+  id?: JsonRpcId;
+}
+
+interface NamedJsonRpcRequest {
+  jsonrpc: "2.0";
+  method: string;
+  params: Record<string, unknown>;
+  id?: JsonRpcId;
+}
+
+type ParsedJsonRpcRequest =
+  | { kind: "invalid" }
+  | { kind: "named-params"; request: NamedJsonRpcRequest }
+  | { kind: "positional"; request: PositionalJsonRpcRequest };
+
+const hasOwn = (value: object, key: string): boolean => Object.prototype.hasOwnProperty.call(value, key);
+
+function isJsonRpcId(value: unknown): value is JsonRpcId {
+  return typeof value === "string" || typeof value === "number" || value === null;
+}
+
+/**
+ * Parses only the JSON-RPC envelope. Ethereum RPC accepts positional params,
+ * while named params remain a valid JSON-RPC envelope and are rejected later
+ * with -32602.
+ */
+function parseJsonRpcRequest(value: unknown): ParsedJsonRpcRequest {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { kind: "invalid" };
   }
-  // Use 'in' operator for safer property checks on unknown
-  return (
-    "jsonrpc" in obj &&
-    obj.jsonrpc === "2.0" &&
-    "method" in obj &&
-    typeof obj.method === "string" &&
-    (!("params" in obj) || obj.params === undefined || Array.isArray(obj.params) || typeof obj.params === "object") &&
-    "id" in obj &&
-    (typeof obj.id === "string" || typeof obj.id === "number" || obj.id === null)
-  );
+
+  const candidate = value as Record<string, unknown>;
+  if (candidate.jsonrpc !== "2.0" || typeof candidate.method !== "string") {
+    return { kind: "invalid" };
+  }
+
+  const idIsPresent = hasOwn(candidate, "id");
+  if (idIsPresent && !isJsonRpcId(candidate.id)) {
+    return { kind: "invalid" };
+  }
+
+  const base = {
+    jsonrpc: "2.0" as const,
+    method: candidate.method,
+    ...(idIsPresent ? { id: candidate.id as JsonRpcId } : {}),
+  };
+
+  if (!hasOwn(candidate, "params")) {
+    return { kind: "positional", request: { ...base, params: [] } };
+  }
+
+  if (Array.isArray(candidate.params)) {
+    return { kind: "positional", request: { ...base, params: candidate.params } };
+  }
+
+  if (typeof candidate.params === "object" && candidate.params !== null) {
+    return { kind: "named-params", request: { ...base, params: candidate.params as Record<string, unknown> } };
+  }
+
+  return { kind: "invalid" };
 }
 
 // Helper to create a JSON-RPC error response
-function createJsonRpcError(id: number | string | null, code: number, message: string): JsonRpcResponse {
+function createJsonRpcError(id: JsonRpcId, code: number, message: string): JsonRpcResponse {
   return {
     jsonrpc: "2.0",
     id,
@@ -41,8 +92,8 @@ function createJsonRpcError(id: number | string | null, code: number, message: s
   };
 }
 
-function isNotification(request: JsonRpcRequest): boolean {
-  return request.id === null;
+function isNotification(request: { id?: JsonRpcId }): boolean {
+  return !hasOwn(request, "id");
 }
 
 const RPC_OVERRIDE_HEADER = "x-ubq-rpc-candidates";
@@ -755,7 +806,7 @@ async function handleRequest(request: Request, manager: RequestHandlerManager): 
 
   // --- Handle Batch Request ---
   if (Array.isArray(requestBody)) {
-    console.log(`Received batch request for chain ${chainId} with ${requestBody.length} calls.`);
+    console.log("Received batch request for chain " + chainId + " with " + requestBody.length + " calls.");
 
     if (requestBody.length === 0) {
       const errorResponse = createJsonRpcError(null, -32600, "Invalid Request: Received empty batch.");
@@ -765,109 +816,189 @@ async function handleRequest(request: Request, manager: RequestHandlerManager): 
       });
     }
 
-    // Validate all requests in the batch first
-    if (!requestBody.every(isValidJsonRpcRequest)) {
-      const errorResponse = createJsonRpcError(
-        null,
-        -32600,
-        "Invalid Request: Batch contains invalid JSON-RPC object(s).",
-      );
-      return new Response(JSON.stringify(errorResponse), {
-        status: 200, // JSON-RPC compliance: invalid requests return HTTP 200
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
+    type MulticallCandidate = {
+      index: number;
+      originalRequest: PositionalJsonRpcRequest;
+      syntheticId: string;
+      request: Multicall3Request;
+    };
 
-    const multiCallRequests = requestBody.filter((req) => isMulticall3Request(chainId, req));
-    const multiCallRequestSet = new Set<JsonRpcRequest>(multiCallRequests);
-    const otherRequests = requestBody.filter((req) => !multiCallRequestSet.has(req));
+    const responses: Array<JsonRpcResponse | undefined> = new Array(requestBody.length);
+    const directRequests: Array<{ index: number; request: PositionalJsonRpcRequest }> = [];
+    const multicallRequests: MulticallCandidate[] = [];
 
-    // group by block tag and split the array into chunks of 500 to avoid exceeding multicall limits
-    const multiCallRequestsByBlockTag = multiCallRequests.reduce(
-      (acc, req) => {
-        const blockTag = req.params[1];
-        if (!acc[blockTag]) {
-          acc[blockTag] = [];
+    for (const [index, value] of requestBody.entries()) {
+      const parsed = parseJsonRpcRequest(value);
+      if (parsed.kind === "invalid") {
+        responses[index] = createJsonRpcError(null, -32600, "Invalid Request: Not a valid JSON-RPC object.");
+        continue;
+      }
+
+      if (parsed.kind === "named-params") {
+        if (!isNotification(parsed.request)) {
+          responses[index] = createJsonRpcError(
+            parsed.request.id ?? null,
+            -32602,
+            "Invalid params: Named parameters are not supported.",
+          );
         }
-        const currentBatch = acc[blockTag];
-        if (currentBatch.length === 0 || currentBatch[currentBatch.length - 1].length >= 500) {
-          currentBatch.push([req]);
-        } else {
-          currentBatch[currentBatch.length - 1].push(req);
-        }
-        return acc;
-      },
-      {} as Record<string, Multicall3Request[][]>,
-    );
+        continue;
+      }
 
-    const multicallPromises: Promise<JsonRpcResponse[]>[] = [];
-    for (const [blockTag, batches] of Object.entries(multiCallRequestsByBlockTag)) {
-      for (const batch of batches) {
-        multicallPromises.push(manager.multicall3(chainId, batch, blockTag, overrideOptions ?? undefined));
+      if (isNotification(parsed.request)) {
+        directRequests.push({ index, request: parsed.request });
+        continue;
+      }
+
+      // multicall3 deduplicates based on request IDs. Give each candidate a
+      // unique per-batch ID, then restore the client ID below.
+      const syntheticId = "__uos_multicall_" + index;
+      const candidate: JsonRpcRequest = {
+        jsonrpc: parsed.request.jsonrpc,
+        id: syntheticId,
+        method: parsed.request.method,
+        params: parsed.request.params,
+      };
+
+      if (isMulticall3Request(chainId, candidate)) {
+        multicallRequests.push({
+          index,
+          originalRequest: parsed.request,
+          syntheticId,
+          request: candidate,
+        });
+      } else {
+        directRequests.push({ index, request: parsed.request });
       }
     }
-    const multicallResponses = (await Promise.all(multicallPromises)).flat();
 
-    // Process batch requests concurrently
-    const otherResponses = await Promise.all(
-      otherRequests.map(async (req) => {
-        const notification = isNotification(req);
-        try {
-          // Ensure params is always an array for manager.send()
-          const params = Array.isArray(req.params) ? req.params : [];
-          const result = await manager.send(chainId, req.method, params, overrideOptions ?? undefined);
-          if (notification) return null;
-          return { jsonrpc: "2.0", id: req.id, result } as JsonRpcResponse;
-        } catch (e) {
-          const error = e instanceof Error ? e : new Error(String(e));
-          console.error(
-            `Error processing batch item (id: ${req.id}, method: ${req.method}) for chain ${chainId}:`,
-            redactRpcDiagnostic(error),
-          );
-
-          if (notification) return null;
-
-          // Extract error details consistently
-          const code = error.name === "JsonRpcError" && "code" in error && typeof error.code === "number"
-            ? error.code
-            : -32603;
-          const data = "data" in error ? redactRpcDiagnostic(error.data) : undefined;
-
-          return {
-            jsonrpc: "2.0",
-            id: req.id,
-            error: {
-              code,
-              message: redactRpcDiagnostic(error.message),
-              data,
-            },
-          } as JsonRpcResponse;
+    const directRequestPromises = directRequests.map(async ({ index, request: rpcRequest }) => {
+      const notification = isNotification(rpcRequest);
+      try {
+        const result = await manager.send(chainId, rpcRequest.method, rpcRequest.params, overrideOptions ?? undefined);
+        if (!notification) {
+          responses[index] = { jsonrpc: "2.0", id: rpcRequest.id ?? null, result };
         }
-      }),
-    );
+      } catch (e) {
+        const error = e instanceof Error ? e : new Error(String(e));
+        console.error(
+          "Error processing batch item (id: " + rpcRequest.id + ", method: " + rpcRequest.method + ") for chain " +
+            chainId + ":",
+          redactRpcDiagnostic(error),
+        );
 
-    const responses = [
-      ...multicallResponses,
-      ...otherResponses.filter((response): response is JsonRpcResponse => response !== null),
-    ];
-    if (responses.length === 0) return noContentResponse();
+        if (notification) return;
 
-    return new Response(JSON.stringify(responses), {
+        const code = error.name === "JsonRpcError" && "code" in error && typeof error.code === "number"
+          ? error.code
+          : -32603;
+        const data = "data" in error ? redactRpcDiagnostic(error.data) : undefined;
+        responses[index] = {
+          jsonrpc: "2.0",
+          id: rpcRequest.id ?? null,
+          error: {
+            code,
+            message: redactRpcDiagnostic(error.message),
+            data,
+          },
+        };
+      }
+    });
+
+    // Group multicall candidates by block tag and split each group into chunks
+    // of 500 to avoid exceeding multicall limits.
+    const multicallRequestsByBlockTag = new Map<string | number, MulticallCandidate[]>();
+    for (const request of multicallRequests) {
+      const blockTag = request.request.params[1];
+      const requestsForBlockTag = multicallRequestsByBlockTag.get(blockTag) ?? [];
+      requestsForBlockTag.push(request);
+      multicallRequestsByBlockTag.set(blockTag, requestsForBlockTag);
+    }
+
+    const multicallPromises: Promise<void>[] = [];
+    for (const [blockTag, requestsForBlockTag] of multicallRequestsByBlockTag) {
+      for (let start = 0; start < requestsForBlockTag.length; start += 500) {
+        const requestBatch = requestsForBlockTag.slice(start, start + 500);
+        multicallPromises.push((async () => {
+          try {
+            const multicallResponses = await manager.multicall3(
+              chainId,
+              requestBatch.map(({ request: rpcRequest }) => rpcRequest),
+              blockTag,
+              overrideOptions ?? undefined,
+            );
+            const responsesBySyntheticId = new Map<string, JsonRpcResponse>();
+            for (const response of multicallResponses) {
+              if (typeof response.id === "string") {
+                responsesBySyntheticId.set(response.id, response);
+              }
+            }
+
+            for (const request of requestBatch) {
+              const response = responsesBySyntheticId.get(request.syntheticId);
+              if (!response) {
+                responses[request.index] = createJsonRpcError(
+                  request.originalRequest.id ?? null,
+                  -32603,
+                  "Internal error: Multicall response missing.",
+                );
+                continue;
+              }
+              responses[request.index] = { ...response, id: request.originalRequest.id ?? null };
+            }
+          } catch (e) {
+            const error = e instanceof Error ? e : new Error(String(e));
+            console.error(
+              "Error processing multicall batch for chain " + chainId + ":",
+              redactRpcDiagnostic(error),
+            );
+            const code = error.name === "JsonRpcError" && "code" in error && typeof error.code === "number"
+              ? error.code
+              : -32603;
+            const data = "data" in error ? redactRpcDiagnostic(error.data) : undefined;
+            for (const request of requestBatch) {
+              responses[request.index] = {
+                jsonrpc: "2.0",
+                id: request.originalRequest.id ?? null,
+                error: {
+                  code,
+                  message: redactRpcDiagnostic(error.message),
+                  data,
+                },
+              };
+            }
+          }
+        })());
+      }
+    }
+
+    await Promise.all([...directRequestPromises, ...multicallPromises]);
+
+    const responseBody = responses.filter((response): response is JsonRpcResponse => response !== undefined);
+    if (responseBody.length === 0) return noContentResponse();
+
+    return new Response(JSON.stringify(responseBody), {
       status: 200,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
-  } // --- Handle Single Request ---
-  else if (isValidJsonRpcRequest(requestBody)) {
-    console.log(`Received single request for chain ${chainId}: ${requestBody.method}`);
-    const notification = isNotification(requestBody);
+  }
+
+  // --- Handle Single Request ---
+  const parsedRequest = parseJsonRpcRequest(requestBody);
+  if (parsedRequest.kind === "positional") {
+    console.log("Received single request for chain " + chainId + ": " + parsedRequest.request.method);
+    const notification = isNotification(parsedRequest.request);
     try {
-      // Ensure params is always an array for manager.send()
-      const params = Array.isArray(requestBody.params) ? requestBody.params : [];
-      const result = await manager.send(chainId, requestBody.method, params, overrideOptions ?? undefined);
+      const result = await manager.send(
+        chainId,
+        parsedRequest.request.method,
+        parsedRequest.request.params,
+        overrideOptions ?? undefined,
+      );
       if (notification) return noContentResponse();
       const rpcResponse: JsonRpcResponse = {
         jsonrpc: "2.0",
-        id: requestBody.id,
+        id: parsedRequest.request.id ?? null,
         result,
       };
       return new Response(JSON.stringify(rpcResponse), {
@@ -877,22 +1008,16 @@ async function handleRequest(request: Request, manager: RequestHandlerManager): 
     } catch (e) {
       const error = e instanceof Error ? e : new Error(String(e));
       console.error(
-        `Error processing single request (id: ${requestBody.id}, method: ${requestBody.method}) for chain ${chainId}:`,
+        "Error processing single request (id: " + parsedRequest.request.id + ", method: " +
+          parsedRequest.request.method + ") for chain " + chainId + ":",
         redactRpcDiagnostic(error),
       );
 
       if (notification) return noContentResponse();
 
-      // Pass through HTTP status if available, otherwise default to 200 for JSON-RPC compliance
-      // Contract reverts and JSON-RPC errors should return HTTP 200 per JSON-RPC spec
-      let httpStatus = 200;
-      if (error.name === "JsonRpcError" && "httpStatus" in error && typeof error.httpStatus === "number") {
-        httpStatus = error.httpStatus;
-      }
-
       const errorResponse = {
         jsonrpc: "2.0",
-        id: requestBody.id,
+        id: parsedRequest.request.id ?? null,
         error: {
           code: "code" in error && typeof error.code === "number" ? error.code : -32603,
           message: redactRpcDiagnostic(error.message),
@@ -901,19 +1026,34 @@ async function handleRequest(request: Request, manager: RequestHandlerManager): 
       };
 
       return new Response(JSON.stringify(errorResponse), {
-        status: httpStatus,
+        // Application-level JSON-RPC errors always use the same response
+        // status as their batch equivalents; protocol details stay in body.
+        status: 200,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
-  } // --- Handle Invalid Request Structure ---
-  else {
-    console.error("Invalid request body structure:", redactRpcDiagnostic(requestBody));
-    const errorResponse = createJsonRpcError(null, -32600, "Invalid Request: Not a valid JSON-RPC object or batch.");
+  }
+
+  if (parsedRequest.kind === "named-params") {
+    if (isNotification(parsedRequest.request)) return noContentResponse();
+    const errorResponse = createJsonRpcError(
+      parsedRequest.request.id ?? null,
+      -32602,
+      "Invalid params: Named parameters are not supported.",
+    );
     return new Response(JSON.stringify(errorResponse), {
-      status: 200, // JSON-RPC compliance: invalid requests return HTTP 200
+      status: 200,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   }
+
+  // --- Handle Invalid Request Structure ---
+  console.error("Invalid request body structure:", redactRpcDiagnostic(requestBody));
+  const errorResponse = createJsonRpcError(null, -32600, "Invalid Request: Not a valid JSON-RPC object or batch.");
+  return new Response(JSON.stringify(errorResponse), {
+    status: 200, // JSON-RPC compliance: invalid requests return HTTP 200
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
 }
 
 if (import.meta.main) {

--- a/packages/permit2-rpc-server/src/deno-server_batch.test.ts
+++ b/packages/permit2-rpc-server/src/deno-server_batch.test.ts
@@ -41,7 +41,7 @@ Deno.test("HTTP batch responses preserve ordinary JSON-RPC ID 0", async () => {
   ]);
 });
 
-Deno.test("HTTP batches execute null-ID notifications without returning them", async () => {
+Deno.test("HTTP batches preserve explicit null IDs as response-bearing requests", async () => {
   const calls: Array<{ chainId: number; method: string; params: unknown[] }> = [];
   const manager: RequestHandlerManager = {
     getHealthStatus: () => Promise.resolve({}),
@@ -65,11 +65,24 @@ Deno.test("HTTP batches execute null-ID notifications without returning them", a
 
   assert.equal(response.status, 200);
   assert.deepEqual(await response.json(), [
+    { jsonrpc: "2.0", id: null, result: { method: "eth_chainId" } },
     { jsonrpc: "2.0", id: 0, result: { method: "eth_blockNumber" } },
   ]);
+
+  const singleResponse = await createHandler(manager)(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: null, method: "eth_gasPrice", params: [] }),
+    }),
+  );
+  assert.equal(singleResponse.status, 200);
+  assert.deepEqual(await singleResponse.json(), { jsonrpc: "2.0", id: null, result: { method: "eth_gasPrice" } });
+
   assert.deepEqual(calls, [
     { chainId: 1, method: "eth_chainId", params: [] },
     { chainId: 1, method: "eth_blockNumber", params: [] },
+    { chainId: 1, method: "eth_gasPrice", params: [] },
   ]);
 });
 
@@ -90,7 +103,6 @@ Deno.test("HTTP notifications execute directly and return no content", async () 
   const handler = createHandler(manager);
   const notification = {
     jsonrpc: "2.0",
-    id: null,
     method: "eth_call",
     params: [{ to: "0x0000000000000000000000000000000000000001", data: "0x" }, "latest"],
   };
@@ -104,6 +116,8 @@ Deno.test("HTTP notifications execute directly and return no content", async () 
   );
   assert.equal(batchResponse.status, 204);
   assert.equal(await batchResponse.text(), "");
+  assert.equal(batchResponse.headers.get("access-control-allow-origin"), "*");
+  assert.equal(batchResponse.headers.get("content-type"), null);
 
   const singleResponse = await handler(
     new Request("http://localhost/1", {
@@ -114,10 +128,284 @@ Deno.test("HTTP notifications execute directly and return no content", async () 
   );
   assert.equal(singleResponse.status, 204);
   assert.equal(await singleResponse.text(), "");
+  assert.equal(singleResponse.headers.get("access-control-allow-origin"), "*");
+  assert.equal(singleResponse.headers.get("content-type"), null);
   assert.equal(multicallCalls, 0);
   assert.deepEqual(calls, [
     { chainId: 1, method: "eth_call", params: notification.params },
     { chainId: 1, method: "eth_call", params: notification.params },
+  ]);
+});
+
+Deno.test("HTTP JSON-RPC batches normalize params and isolate invalid elements", async () => {
+  const calls: Array<{ chainId: number; method: string; params: unknown[] }> = [];
+  const manager: RequestHandlerManager = {
+    getHealthStatus: () => Promise.resolve({}),
+    multicall3: () => Promise.resolve([]),
+    send: <T = unknown>(chainId: number, method: string, params: unknown[] = []): Promise<T> => {
+      calls.push({ chainId, method, params });
+      return Promise.resolve({ method } as T);
+    },
+  };
+  const handler = createHandler(manager);
+
+  const response = await handler(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([
+        { jsonrpc: "2.0", id: 1, method: "eth_chainId" },
+        { jsonrpc: "2.0", method: "eth_blockNumber", params: [] },
+        { jsonrpc: "2.0", id: 3, method: "eth_getBalance", params: null },
+        { jsonrpc: "2.0", id: 4, method: "eth_getBalance", params: { address: "0x1" } },
+        { jsonrpc: "2.0", id: null, method: "eth_gasPrice", params: [] },
+      ]),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), [
+    { jsonrpc: "2.0", id: 1, result: { method: "eth_chainId" } },
+    { jsonrpc: "2.0", id: null, error: { code: -32600, message: "Invalid Request: Not a valid JSON-RPC object." } },
+    {
+      jsonrpc: "2.0",
+      id: 4,
+      error: { code: -32602, message: "Invalid params: Named parameters are not supported." },
+    },
+    { jsonrpc: "2.0", id: null, result: { method: "eth_gasPrice" } },
+  ]);
+  assert.deepEqual(calls, [
+    { chainId: 1, method: "eth_chainId", params: [] },
+    { chainId: 1, method: "eth_blockNumber", params: [] },
+    { chainId: 1, method: "eth_gasPrice", params: [] },
+  ]);
+
+  const primitiveParamsResponse = await handler(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 5, method: "eth_getBalance", params: 1 }),
+    }),
+  );
+  assert.equal(primitiveParamsResponse.status, 200);
+  assert.deepEqual(await primitiveParamsResponse.json(), {
+    jsonrpc: "2.0",
+    id: null,
+    error: { code: -32600, message: "Invalid Request: Not a valid JSON-RPC object or batch." },
+  });
+});
+
+Deno.test("HTTP empty batches return one invalid-request object", async () => {
+  const manager: RequestHandlerManager = {
+    getHealthStatus: () => Promise.resolve({}),
+    multicall3: () => Promise.resolve([]),
+    send: <T = unknown>(): Promise<T> => Promise.resolve(undefined as T),
+  };
+
+  const response = await createHandler(manager)(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([]),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    jsonrpc: "2.0",
+    id: null,
+    error: { code: -32600, message: "Invalid Request: Received empty batch." },
+  });
+});
+
+Deno.test("HTTP named-params notifications suppress responses", async () => {
+  let sendCalls = 0;
+  const manager: RequestHandlerManager = {
+    getHealthStatus: () => Promise.resolve({}),
+    multicall3: () => Promise.resolve([]),
+    send: <T = unknown>(): Promise<T> => {
+      sendCalls++;
+      return Promise.resolve(undefined as T);
+    },
+  };
+
+  const response = await createHandler(manager)(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "eth_getBalance", params: { address: "0x1" } }),
+    }),
+  );
+
+  assert.equal(response.status, 204);
+  assert.equal(await response.text(), "");
+  assert.equal(response.headers.get("content-type"), null);
+  assert.equal(sendCalls, 0);
+});
+
+Deno.test("MCP dispatch accepts named object params before Ethereum JSON-RPC validation", async () => {
+  let sendCalls = 0;
+  const manager: RequestHandlerManager = {
+    getHealthStatus: () => Promise.resolve({}),
+    multicall3: () => Promise.resolve([]),
+    send: <T = unknown>(): Promise<T> => {
+      sendCalls++;
+      return Promise.resolve(undefined as T);
+    },
+  };
+
+  const response = await createHandler(manager)(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: "mcp", method: "tools/list", params: {} }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.id, "mcp");
+  assert.ok(Array.isArray(body.result.tools));
+  assert.equal(sendCalls, 0);
+});
+
+Deno.test("MCP-shaped objects still require a valid JSON-RPC envelope", async () => {
+  const manager: RequestHandlerManager = {
+    getHealthStatus: () => Promise.resolve({}),
+    multicall3: () => Promise.resolve([]),
+    send: <T = unknown>(): Promise<T> => Promise.resolve(undefined as T),
+  };
+  const handler = createHandler(manager);
+
+  for (
+    const requestBody of [
+      { jsonrpc: "1.0", id: 1, method: "tools/list", params: {} },
+      { jsonrpc: "2.0", id: true, method: "tools/list", params: {} },
+      { method: "tools/list", params: {} },
+      { jsonrpc: "2.0", id: 1, method: "tools/list", params: null },
+      { jsonrpc: "2.0", id: 1, method: "tools/list", params: 1 },
+    ]
+  ) {
+    const response = await handler(
+      new Request("http://localhost/1", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(requestBody),
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32600, message: "Invalid Request: Not a valid JSON-RPC object or batch." },
+    });
+  }
+});
+
+Deno.test("MCP notifications suppress responses while explicit null IDs remain response-bearing", async () => {
+  const calls: Array<{ chainId: number; method: string; params: unknown[] }> = [];
+  const manager: RequestHandlerManager = {
+    getHealthStatus: () => Promise.resolve({}),
+    multicall3: () => Promise.resolve([]),
+    send: <T = unknown>(chainId: number, method: string, params: unknown[] = []): Promise<T> => {
+      calls.push({ chainId, method, params });
+      return Promise.resolve("0x1" as T);
+    },
+  };
+  const handler = createHandler(manager);
+  const mcpCall = {
+    jsonrpc: "2.0",
+    method: "tools/call",
+    params: { name: "eth_chainId", arguments: {} },
+  };
+
+  const notificationResponse = await handler(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(mcpCall),
+    }),
+  );
+
+  assert.equal(notificationResponse.status, 204);
+  assert.equal(await notificationResponse.text(), "");
+  assert.equal(notificationResponse.headers.get("access-control-allow-origin"), "*");
+  assert.equal(notificationResponse.headers.get("content-type"), null);
+  assert.deepEqual(calls, [{ chainId: 1, method: "eth_chainId", params: [] }]);
+
+  const explicitNullResponse = await handler(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...mcpCall, id: null }),
+    }),
+  );
+
+  assert.equal(explicitNullResponse.status, 200);
+  const body = await explicitNullResponse.json();
+  assert.equal(body.id, null);
+  assert.equal(body.result.content[0].text, '"0x1"');
+  assert.deepEqual(calls, [
+    { chainId: 1, method: "eth_chainId", params: [] },
+    { chainId: 1, method: "eth_chainId", params: [] },
+  ]);
+});
+
+Deno.test("HTTP multicall responses restore client IDs and input order", async () => {
+  let multicallIds: Array<number | string | null> = [];
+  const manager: RequestHandlerManager = {
+    getHealthStatus: () => Promise.resolve({}),
+    multicall3: (_chainId, requests) => {
+      multicallIds = requests.map((request) => request.id);
+      return Promise.resolve(
+        [...requests].reverse().map((request) => ({
+          jsonrpc: "2.0" as const,
+          id: request.id,
+          result: "multicall:" + request.id,
+        })),
+      );
+    },
+    send: <T = unknown>(_chainId: number, method: string): Promise<T> => {
+      return Promise.resolve(("direct:" + method) as T);
+    },
+  };
+
+  const response = await createHandler(manager)(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([
+        {
+          jsonrpc: "2.0",
+          id: "duplicate",
+          method: "eth_call",
+          params: [{ to: "0x0000000000000000000000000000000000000001", data: "0xaaaa" }, "latest"],
+        },
+        {
+          jsonrpc: "2.0",
+          id: null,
+          method: "eth_call",
+          params: [{ to: "0x0000000000000000000000000000000000000001", data: "0xaaaa" }, "latest"],
+        },
+        { jsonrpc: "2.0", id: "direct", method: "eth_chainId", params: [] },
+        {
+          jsonrpc: "2.0",
+          id: "duplicate",
+          method: "eth_call",
+          params: [{ to: "0x0000000000000000000000000000000000000001", data: "0xbbbb" }, "latest"],
+        },
+      ]),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(multicallIds, ["__uos_multicall_0", "__uos_multicall_1", "__uos_multicall_3"]);
+  assert.deepEqual(await response.json(), [
+    { jsonrpc: "2.0", id: "duplicate", result: "multicall:__uos_multicall_0" },
+    { jsonrpc: "2.0", id: null, result: "multicall:__uos_multicall_1" },
+    { jsonrpc: "2.0", id: "direct", result: "direct:eth_chainId" },
+    { jsonrpc: "2.0", id: "duplicate", result: "multicall:__uos_multicall_3" },
   ]);
 });
 
@@ -146,4 +434,38 @@ Deno.test("HTTP errors redact upstream credentials from message and data", async
   assert.doesNotMatch(serializedBody, /rpc-user:rpc-password/);
   assert.doesNotMatch(serializedBody, /secret-query-token/);
   assert.match(serializedBody, /rpc-[0-9a-f]{16}/);
+});
+
+Deno.test("HTTP JSON-RPC application errors use status 200 for single and batch requests", async () => {
+  const upstreamError = Object.assign(new Error("limit exceeded"), {
+    name: "JsonRpcError",
+    code: -32005,
+    httpStatus: 429,
+  });
+  const manager: RequestHandlerManager = {
+    getHealthStatus: () => Promise.resolve({}),
+    multicall3: () => Promise.resolve([]),
+    send: <T = unknown>(): Promise<T> => Promise.reject(upstreamError),
+  };
+  const handler = createHandler(manager);
+
+  const singleResponse = await handler(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: [] }),
+    }),
+  );
+  assert.equal(singleResponse.status, 200);
+  assert.equal((await singleResponse.json()).error.code, -32005);
+
+  const batchResponse = await handler(
+    new Request("http://localhost/1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([{ jsonrpc: "2.0", id: 2, method: "eth_blockNumber", params: [] }]),
+    }),
+  );
+  assert.equal(batchResponse.status, 200);
+  assert.equal((await batchResponse.json())[0].error.code, -32005);
 });

--- a/packages/permit2-rpc-server/src/evm/multicall3.ts
+++ b/packages/permit2-rpc-server/src/evm/multicall3.ts
@@ -62,7 +62,7 @@ export const isMulticall3Request = (chainId: number, req: JsonRpcRequest): req i
   }
 
   return (
-    req.id !== null &&
+    (typeof req.id === "number" || typeof req.id === "string") &&
     chainId in multicall3Addresses &&
     req.method === "eth_call" &&
     "to" in call &&

--- a/packages/permit2-rpc-server/src/evm/multicall3_test.ts
+++ b/packages/permit2-rpc-server/src/evm/multicall3_test.ts
@@ -44,6 +44,18 @@ Deno.test("isMulticall3Request: accepts ID 0", () => {
   assertEquals(isMulticall3Request(chainId, idZeroRequest), true);
 });
 
+Deno.test("isMulticall3Request: rejects explicit null IDs and notifications", () => {
+  const nullIdRequest = { ...baseRequest, id: null } satisfies JsonRpcRequest;
+  const notification = {
+    jsonrpc: "2.0" as const,
+    method: "eth_call",
+    params: [baseCall, "latest"],
+  } satisfies JsonRpcRequest;
+
+  assertEquals(isMulticall3Request(chainId, nullIdRequest), false);
+  assertEquals(isMulticall3Request(chainId, notification), false);
+});
+
 Deno.test("isMulticall3Request: rejects every sender-sensitive Permit2 selector", () => {
   for (const selector of senderSensitiveSelectors) {
     const permitCall = {

--- a/packages/permit2-rpc-server/src/mcp/handler.ts
+++ b/packages/permit2-rpc-server/src/mcp/handler.ts
@@ -3,6 +3,12 @@ import { redactRpcDiagnostic } from "../core/rpc-endpoint-id.ts";
 import { buildRpcParams } from "./ethereum-rpc-params.ts";
 import { getEthereumTools } from "./ethereum-tools.ts";
 
+const hasOwn = (value: object, key: string): boolean => Object.prototype.hasOwnProperty.call(value, key);
+
+const isJsonRpcId = (value: unknown): value is string | number | null => {
+  return typeof value === "string" || typeof value === "number" || value === null;
+};
+
 function parseChainIdFromSinglePathPart(pathParts: string[]): number {
   if (pathParts.length !== 1) return 1;
   const parsed = parseInt(pathParts[0], 10);
@@ -21,15 +27,18 @@ function parseChainIdOverride(value: unknown): number | undefined {
 }
 
 export function isMcpRequest(body: unknown): boolean {
-  if (typeof body === "object" && body !== null && "method" in body) {
-    const method = (body as any).method;
-    return (
-      typeof method === "string" &&
-      (method === "initialize" || method.startsWith("tools/") || method.startsWith("resources/") ||
-        method.startsWith("prompts/"))
-    );
+  if (typeof body !== "object" || body === null || Array.isArray(body)) return false;
+
+  const candidate = body as Record<string, unknown>;
+  if (candidate.jsonrpc !== "2.0" || typeof candidate.method !== "string") return false;
+  if (hasOwn(candidate, "id") && !isJsonRpcId(candidate.id)) return false;
+  if (hasOwn(candidate, "params") && (candidate.params === null || typeof candidate.params !== "object")) {
+    return false;
   }
-  return false;
+
+  const { method } = candidate;
+  return method === "initialize" || method.startsWith("tools/") || method.startsWith("resources/") ||
+    method.startsWith("prompts/");
 }
 
 export async function handleMcpRequest(options: {
@@ -39,6 +48,7 @@ export async function handleMcpRequest(options: {
   corsHeaders: Record<string, string>;
 }): Promise<Response> {
   const mcpRequest = options.requestBody as any;
+  const isNotification = !Object.prototype.hasOwnProperty.call(mcpRequest, "id");
   let mcpResponse: any;
 
   let chainId = parseChainIdFromSinglePathPart(options.pathParts);
@@ -105,6 +115,10 @@ export async function handleMcpRequest(options: {
           message: `Method not found: ${mcpRequest.method}`,
         },
       };
+  }
+
+  if (isNotification) {
+    return new Response(null, { status: 204, headers: options.corsHeaders });
   }
 
   return new Response(

--- a/scripts/test-adaptive-pool.ts
+++ b/scripts/test-adaptive-pool.ts
@@ -24,12 +24,11 @@ async function testAdaptivePoolManagement() {
   console.log("Testing Adaptive RPC Pool Management");
   console.log("=====================================\n");
 
-  // Create manager with adaptive pool management enabled
+  // Health tracking is deliberately local to this manager instance. Cache data
+  // remains in CacheManager, but no legacy rpc_failures KV entries are read or
+  // written by the request path.
   const manager = new Permit2RpcManager({
     initialRpcData: mockRpcData,
-    enableBadNetworkInvalidation: true,
-    eliminationThreshold: 3,
-    eliminationRetryMs: 10000, // 10 seconds for testing
     logLevel: "debug",
     disableCache: false,
     cacheTtlMs: 60000, // 1 minute cache
@@ -69,27 +68,20 @@ async function testAdaptivePoolManagement() {
   console.log("- Eliminated RPCs are excluded from selection");
   console.log("- Last remaining RPC is never eliminated to maintain service availability");
 
-  console.log("\n4. Checking KV failure tracking");
-  console.log("--------------------------------");
+  console.log("\n4. Checking in-memory health status");
+  console.log("-----------------------------------");
 
-  const kv = await Deno.openKv();
-  const failures = kv.list({ prefix: ["rpc_failures", 100] });
-
-  console.log("Current failure tracking:");
-  for await (const entry of failures) {
-    const rpcUrl = String(entry.key[2]);
-    console.log(`- ${rpcUrl}: ${JSON.stringify(entry.value)}`);
-  }
+  const health = await manager.getHealthStatus();
+  const chainHealth = health.chains[100];
+  console.log(`Tracked RPCs: ${chainHealth?.totalRpcs ?? 0}`);
+  console.log(`Healthy RPCs: ${chainHealth?.healthyRpcs ?? 0}`);
 
   console.log("\n5. Summary");
   console.log("----------");
   console.log("✓ Adaptive pool management is configured and active");
-  console.log("✓ Failure tracking uses Deno KV with proper key structure");
+  console.log("✓ Failure tracking is manager-local; no rpc_failures KV entries are used");
   console.log("✓ Cache invalidation updates latency results with metadata");
   console.log("✓ RPC selector filters eliminated RPCs from the pool");
-
-  // Cleanup
-  kv.close();
 }
 
 // Run the test


### PR DESCRIPTION
## Summary

- Harden provider-error handling: decoded JSON-RPC semantics take precedence over HTTP wrappers. -32601 and -32004 are endpoint/method capability misses with failover but no health, scorer, throttle, or circuit penalty; -32005 is LIMIT_EXCEEDED and fails over with backoff/throttle accounting.
- Use one accounting path for sequential, hedged, and consensus attempts; add tokenized, cancellation-safe recovery leases and consensus participant backfill.
- Recovery exclusivity is within one Permit2RpcManager instance/isolate only. There is no cross-isolate admission check or hot-path KV coordination.
- Remove application-path rpc_failures KV reads/writes while preserving the independent CacheManager selector cache.
- Bring JSON-RPC handling in line with notifications, explicit id: null, mixed batches, positional-only Ethereum params, ordered multicall restoration, and bodyless CORS 204 responses.
- Redact wrapper-delimited RPC URLs without truncating legal IPv6, semicolon-query, or terminal URL characters.

## Historical review correction

The review output below is retained as historical context. Its references to both -32004 and -32005 as quota codes, and to an unqualified recovery-probe guarantee, are superseded by this resolution.

| Finding | Corrected resolution |
| --- | --- |
| Error-code semantics | -32004 is METHOD_NOT_SUPPORTED; together with -32601, it is a capability-only failover result. -32005 is LIMIT_EXCEEDED and receives backoff/throttle accounting. |
| Structured versus transport errors | Recognized provider JSON-RPC semantics win over HTTP wrappers. Invalid parameters, invalid requests, and deterministic reverts remain non-retryable even under 429/5xx; unknown structured codes and invalid/non-JSON bodies use transport classification. |
| Recovery leases | Opaque tokens make stale releases no-ops. Completed probes consume their expired window or retain newly opened backoff; cancelled hedge losers restore half-open eligibility. This is per manager instance/isolate only. |
| Diagnostics | Head sampling and selector latency tests skip backed-off, half-open, actively probed, and circuit-open endpoints while retaining cached deferred results for foreground recovery. |
| KV scope | The request path no longer opens KV or reads/writes ["rpc_failures"]. The separate CacheManager selector cache remains unchanged. Legacy-entry cleanup is an operator-only post-deploy count/delete operation that does not print keys. |
| URL redaction | Wrapper-aware tokenization preserves legal URL syntax while redacting complete endpoint tokens. |

<details>
<summary>Historical review output (preserved)</summary>

RPC endpoint credentials can still be exposed for valid URL forms, and quota responses delivered with generic 4xx statuses still fail without trying a healthy endpoint. The newly added half-open protection also has stale-window and alternate-execution-path gaps.

Full review comments:

- [P1] Redact complete URLs with legal query and IPv6 characters - packages/permit2-rpc-server/src/core/rpc-endpoint-id.ts:4

  When a diagnostic contains a legal semicolon query delimiter (for example https://rpc.example/?token=a;next=secret) or an IPv6 host, this character class stops matching before part or all of the URL. The replacement then leaves ;next=secret (and for IPv6 the entire URL) in logs and JSON-RPC error bodies, defeating the new credential-redaction guarantee.

- [P1] Classify quota codes before generic 4xx responses - packages/permit2-rpc-server/src/core/permit2-rpc-manager.ts:418-424

  When a provider returns -32004 or -32005 in a valid JSON-RPC body with HTTP 400 (or another generic 4xx), executeRpcCall sets httpStatus and the earlier generic 4xx branch returns DO_NOT_RETRY before this new code runs. The request therefore stops at the quota-limited endpoint instead of failing over to a healthy one; handle these quota codes before the generic 4xx case.

- [P2] Consume a completed backoff window after its recovery probe - packages/permit2-rpc-server/src/core/permit2-rpc-manager.ts:529-536

  When the half-open probe fails with RETRY_DIFFERENT_RPC before maxConsecutiveFailures (or is a METHOD_NOT_FOUND), recordFailure does not replace temporaryUnavailableUntil and releaseRpcAttempt only clears the in-flight flag. Its already-expired timestamp remains, so every later request is serialized as another recovery probe despite no new backoff window. Consume or replace the window once that probe resolves while preserving the in-flight gate.

- [P2] Apply recovery-probe leasing to consensus and hedged requests - packages/permit2-rpc-server/src/core/permit2-rpc-manager.ts:1017-1019

  With RPC_CONSENSUS_ENABLED or RPC_HEDGE_ENABLED, request execution returns through the branches above this loop and calls executeRpcCall without ever acquiring this lease. Concurrent distinct reads after a backoff has expired can therefore send multiple probes to the same endpoint, so the new one-probe recovery policy is only enforced in the default sequential mode.

</details>

## Validation

Local candidate f1fc23d:

- [x] Touched-file deno fmt --check
- [x] cd packages/permit2-rpc-server && deno task lint
- [x] cd packages/permit2-rpc-server && deno task build
- [x] cd packages/permit2-rpc-server && deno task test - 111 passed
- [x] deno check for the updated operator script
- [x] git diff --check
- [x] Final Oracle GPT-5 Pro review of this exact candidate: no actionable P0-P2 findings
- [x] The documented 11-file repository formatting baseline remains outside touched files.

Deno 2 preview (pending this PR head):

- [x] Deno Deploy preview workflow passed for f1fc23d (run 30333496065).
- [x] /health returned 200.
- [x] An eth_chainId notification returned bodyless CORS 204 without JSON content type.
- [x] Explicit id: null returned a normal JSON-RPC response with id: null.
- [x] A mixed batch preserved input response order after notification slots were removed.
- [x] A safe eth_blockNumber read succeeded.

## Release scope

- Squash-merge only after the preview checks above pass, then validate the Deno 2 production workflow and repeat the probes against https://rpc-ubq-fi.ubiquity-dao.deno.net.
- After deployment, use an operator-scoped KV connection to count then delete only legacy ["rpc_failures"] entries from the attached production and preview timelines; report counts only.
- The failing legacy Deno / permit2-rpc-proxy status is the retired Deno Deploy Classic integration and is external to this PR. This bundle does not claim to migrate rpc.ubq.fi DNS/TLS or repair that obsolete Classic-status integration.