### PR TITLE
fix(rpc): retain deferred recovery candidates

### DIFF
--- a/packages/permit2-rpc-server/src/core/permit2-rpc-manager_hardening_test.ts
+++ b/packages/permit2-rpc-server/src/core/permit2-rpc-manager_hardening_test.ts
@@ -532,6 +532,120 @@ Deno.test("a failed recovery probe consumes its expired backoff window", async (
   }
 });
 
+Deno.test("cache-disabled selection retains an expired-backoff endpoint for its foreground recovery lease", async () => {
+  const recoveringRpc = "https://selector-recovery.example";
+  const healthyRpc = "https://selector-healthy.example";
+  const manager = new Permit2RpcManager({
+    initialRpcData: { rpcs: { "1": [recoveringRpc, healthyRpc] } },
+    disableCache: true,
+    logLevel: "none",
+    scoringV2: { enabled: false },
+  });
+  const testedUrls: string[][] = [];
+  const selector = manager.rpcSelector as unknown as {
+    latencyTester: {
+      testRpcUrls(
+        chainId: number,
+        urls: string[],
+      ): Promise<Record<string, { url: string; latency: number; status: "ok" }>>;
+    };
+  };
+  selector.latencyTester = {
+    testRpcUrls: (_chainId, urls) => {
+      testedUrls.push(urls);
+      return Promise.resolve({ [healthyRpc]: { url: healthyRpc, latency: 10, status: "ok" } });
+    },
+  };
+  (manager as any).rpcScorer.getRankedRpcs = (candidates: string[]) => candidates;
+  (manager as any).rpcIndexMap.set(1, 1);
+  markRpcHalfOpen(manager, recoveringRpc);
+
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  let resolveRecovery!: (response: Response) => void;
+  let signalRecoveryFetch!: () => void;
+  const recoveryResponse = new Promise<Response>((resolve) => {
+    resolveRecovery = resolve;
+  });
+  const recoveryFetchStarted = new Promise<void>((resolve) => {
+    signalRecoveryFetch = resolve;
+  });
+
+  globalThis.fetch = ((input) => {
+    calls.push(inputUrl(input));
+    signalRecoveryFetch();
+    return recoveryResponse;
+  }) as typeof fetch;
+
+  try {
+    const recoveryRequest = manager.send<string>(1, "eth_blockNumber");
+    await recoveryFetchStarted;
+
+    assert.deepEqual(testedUrls, [[healthyRpc]]);
+    assert.deepEqual(calls, [recoveringRpc]);
+    assert.equal(typeof (manager as any).rpcHealthStates.get(recoveringRpc).recoveryProbeToken, "string");
+
+    resolveRecovery(jsonResponse({ jsonrpc: "2.0", id: 1, result: "recovered" }));
+    assert.equal(await recoveryRequest, "recovered");
+  } finally {
+    resolveRecovery?.(jsonResponse({ jsonrpc: "2.0", id: 1, result: "recovered" }));
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("cache-disabled selection does not execute active recovery probes or circuit-open endpoints", async () => {
+  const activeProbeRpc = "https://selector-active-probe.example";
+  const circuitOpenRpc = "https://selector-circuit-open.example";
+  const healthyRpc = "https://selector-healthy.example";
+  const manager = new Permit2RpcManager({
+    initialRpcData: { rpcs: { "1": [activeProbeRpc, circuitOpenRpc, healthyRpc] } },
+    disableCache: true,
+    logLevel: "none",
+    scoringV2: { enabled: false },
+  });
+  const testedUrls: string[][] = [];
+  const selector = manager.rpcSelector as unknown as {
+    latencyTester: {
+      testRpcUrls(
+        chainId: number,
+        urls: string[],
+      ): Promise<Record<string, { url: string; latency: number; status: "ok" }>>;
+    };
+  };
+  selector.latencyTester = {
+    testRpcUrls: (_chainId, urls) => {
+      testedUrls.push(urls);
+      return Promise.resolve({ [healthyRpc]: { url: healthyRpc, latency: 10, status: "ok" } });
+    },
+  };
+  (manager as any).rpcScorer.getRankedRpcs = (candidates: string[]) => candidates;
+  markRpcHalfOpen(manager, activeProbeRpc);
+  (manager as any).rpcHealthStates.get(activeProbeRpc).recoveryProbeToken = "already-probing";
+
+  const circuitBreaker = (manager as any).circuitBreaker;
+  for (let index = 0; index < 5; index++) {
+    circuitBreaker.recordResult(circuitOpenRpc, { isProviderIssue: true, reason: "network_error" }, false);
+  }
+
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = ((input) => {
+    calls.push(inputUrl(input));
+    return Promise.reject(new TypeError("Failed to fetch"));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(() => manager.send(1, "eth_blockNumber"));
+
+    assert.deepEqual(testedUrls, [[healthyRpc]]);
+    assert.deepEqual(calls, [healthyRpc]);
+    assert.equal((manager as any).rpcHealthStates.get(activeProbeRpc).recoveryProbeToken, "already-probing");
+    assert.equal(circuitBreaker.getState(circuitOpenRpc), "open");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 Deno.test("consensus requests allow only one half-open recovery probe", async () => {
   const recoveringRpc = "https://recovering-consensus.example";
   const healthyRpc = "https://healthy-consensus.example";

--- a/packages/permit2-rpc-server/src/core/rpc-selector.ts
+++ b/packages/permit2-rpc-server/src/core/rpc-selector.ts
@@ -60,6 +60,7 @@ export class RpcSelector {
     const allowedUrls = new Set(rpcUrls);
     const deferredUrls = new Set(rpcUrls.filter((url) => !this.isDiagnosticEligible(url)));
     const diagnosticUrls = rpcUrls.filter((url) => !deferredUrls.has(url));
+    const diagnosticUrlSet = new Set(diagnosticUrls);
 
     let latencyMap = await this.cacheManager.getLatencyMap(chainId);
     // Use const as this variable is not reassigned before the next block
@@ -107,7 +108,7 @@ export class RpcSelector {
         try {
           latencyMap = this.mergeLatencyMaps(await testPromise, latencyMap, allowedUrls, deferredUrls);
           // Find the new fastest based on the fresh test results
-          const newFastest = this._findFastestInMap(latencyMap);
+          const newFastest = this._findFastestInMap(latencyMap, diagnosticUrlSet);
           await this.cacheManager.updateChainCache(chainId, latencyMap, newFastest?.url ?? null);
           if (newFastest) {
             this.log(
@@ -138,7 +139,16 @@ export class RpcSelector {
     }
 
     // Filter and sort the results from the (potentially updated) latency map
-    const rankedList = this._rankResults(latencyMap, allowedUrls);
+    const rankedList = this._rankResults(latencyMap, diagnosticUrlSet);
+    const rankedUrls = new Set(rankedList);
+
+    for (const url of rpcUrls) {
+      if (deferredUrls.has(url) && !rankedUrls.has(url)) {
+        rankedList.push(url);
+        rankedUrls.add(url);
+      }
+    }
+
     this.log("debug", `Ranked RPC list for chain ${chainId}:`, redactRpcDiagnostic(rankedList));
     return rankedList;
   }
@@ -146,7 +156,10 @@ export class RpcSelector {
   /**
    * Helper to find the single best RPC from a latency map based on status and latency.
    */
-  private _findFastestInMap(latencyMap: Record<string, LatencyTestResult> | null): LatencyTestResult | null {
+  private _findFastestInMap(
+    latencyMap: Record<string, LatencyTestResult> | null,
+    allowedUrls: Set<string>,
+  ): LatencyTestResult | null {
     if (!latencyMap) return null;
 
     let bestResult: LatencyTestResult | null = null;
@@ -155,7 +168,7 @@ export class RpcSelector {
       let fastestForStatus: LatencyTestResult | null = null;
       for (const url in latencyMap) {
         const result = latencyMap[url];
-        if (result?.status === status) {
+        if (result?.status === status && allowedUrls.has(result.url)) {
           if (!fastestForStatus || result.latency < fastestForStatus.latency) {
             fastestForStatus = result;
           }

--- a/packages/permit2-rpc-server/src/core/rpc-selector_test.ts
+++ b/packages/permit2-rpc-server/src/core/rpc-selector_test.ts
@@ -94,7 +94,7 @@ Deno.test("RpcSelector: ignores cached fastest RPC not in data source", async ()
   assertEquals(ranked, [okRpc]);
 });
 
-Deno.test("RpcSelector: skips deferred diagnostics while retaining cached recovery candidates", async () => {
+Deno.test("RpcSelector: appends cached deferred recovery candidates after fresh diagnostics", async () => {
   const chainId = 1;
   const deferredRpc = "https://deferred.example/rpc";
   const healthyRpc = "https://healthy.example/rpc";
@@ -128,18 +128,49 @@ Deno.test("RpcSelector: skips deferred diagnostics while retaining cached recove
   const ranked = await selector.getRankedRpcList(chainId);
 
   assertEquals(testedUrls, [[healthyRpc]]);
-  assertEquals(ranked, [deferredRpc, healthyRpc]);
+  assertEquals(ranked, [healthyRpc, deferredRpc]);
   const retainedMap = await cacheManager.getLatencyMap(chainId);
   assertEquals(retainedMap?.[deferredRpc], { url: deferredRpc, latency: 1, status: "ok" });
+  assertEquals(await cacheManager.getFastestRpc(chainId), healthyRpc);
 });
 
-Deno.test("RpcSelector: excludes backed-off, half-open, and active-probe diagnostics while retaining cached candidates", async () => {
+Deno.test("RpcSelector: retains uncached deferred recovery candidates after fresh diagnostics", async () => {
+  const chainId = 1;
+  const deferredRpc = "https://deferred.example/rpc";
+  const healthyRpc = "https://healthy.example/rpc";
+  const dataSource = { getRpcUrls: () => [deferredRpc, healthyRpc] };
+  const cacheManager = new CacheManager({ disableCache: true });
+  const testedUrls: string[][] = [];
+
+  const latencyTester = {
+    testRpcUrls: (_chainId: number, urls: string[]): Promise<Record<string, LatencyTestResult>> => {
+      testedUrls.push(urls);
+      return Promise.resolve({ [healthyRpc]: { url: healthyRpc, latency: 10, status: "ok" } });
+    },
+  };
+
+  const selector = new RpcSelector(
+    dataSource,
+    cacheManager,
+    latencyTester,
+    undefined,
+    (url) => url === healthyRpc,
+  );
+  const ranked = await selector.getRankedRpcList(chainId);
+
+  assertEquals(testedUrls, [[healthyRpc]]);
+  assertEquals(ranked, [healthyRpc, deferredRpc]);
+  assertEquals(await cacheManager.getLatencyMap(chainId), null);
+});
+
+Deno.test("RpcSelector: excludes backed-off, half-open, active-probe, and circuit-open diagnostics while retaining cached candidates", async () => {
   const chainId = 1;
   const backedOffRpc = "https://backed-off.example/rpc";
   const halfOpenRpc = "https://half-open.example/rpc";
   const activeProbeRpc = "https://active-probe.example/rpc";
+  const circuitOpenRpc = "https://circuit-open.example/rpc";
   const healthyRpc = "https://healthy.example/rpc";
-  const dataSource = { getRpcUrls: () => [backedOffRpc, halfOpenRpc, activeProbeRpc, healthyRpc] };
+  const dataSource = { getRpcUrls: () => [backedOffRpc, halfOpenRpc, activeProbeRpc, circuitOpenRpc, healthyRpc] };
   const cacheManager = new MemoryCacheManager();
   const testedUrls: string[][] = [];
 
@@ -149,6 +180,7 @@ Deno.test("RpcSelector: excludes backed-off, half-open, and active-probe diagnos
       [backedOffRpc]: { url: backedOffRpc, latency: 1, status: "ok" },
       [halfOpenRpc]: { url: halfOpenRpc, latency: 2, status: "ok" },
       [activeProbeRpc]: { url: activeProbeRpc, latency: 3, status: "ok" },
+      [circuitOpenRpc]: { url: circuitOpenRpc, latency: 4, status: "ok" },
       [healthyRpc]: { url: healthyRpc, latency: 20, status: "ok" },
     },
     null,
@@ -171,11 +203,12 @@ Deno.test("RpcSelector: excludes backed-off, half-open, and active-probe diagnos
   const ranked = await selector.getRankedRpcList(chainId);
 
   assertEquals(testedUrls, [[healthyRpc]]);
-  assertEquals(ranked, [backedOffRpc, halfOpenRpc, activeProbeRpc, healthyRpc]);
+  assertEquals(ranked, [healthyRpc, backedOffRpc, halfOpenRpc, activeProbeRpc, circuitOpenRpc]);
   const retainedMap = await cacheManager.getLatencyMap(chainId);
   assertEquals(retainedMap?.[backedOffRpc], { url: backedOffRpc, latency: 1, status: "ok" });
   assertEquals(retainedMap?.[halfOpenRpc], { url: halfOpenRpc, latency: 2, status: "ok" });
   assertEquals(retainedMap?.[activeProbeRpc], { url: activeProbeRpc, latency: 3, status: "ok" });
+  assertEquals(retainedMap?.[circuitOpenRpc], { url: circuitOpenRpc, latency: 4, status: "ok" });
 });
 
 Deno.test("RpcSelector: redacts RPC URLs from selector diagnostics", async () => {


### PR DESCRIPTION
## Summary

- Retain health-deferred whitelist endpoints as foreground candidates when selector caching is disabled.
- Keep latency diagnostics limited to eligible endpoints; no synthetic latency records or deferred cache entries are created.
- Add cache-disabled selector and manager regressions for recovery leases, active probes, and circuit-open endpoints.

## Why

A mixed healthy/deferred whitelist could drop the deferred endpoint after a cache-disabled refresh, preventing its expired-backoff recovery lease from ever being acquired.

## Validation

- `deno fmt --check` on touched files
- `cd packages/permit2-rpc-server && deno task lint`
- `cd packages/permit2-rpc-server && deno task build`
- `cd packages/permit2-rpc-server && deno task test` (114 passed)
- `git diff --check`
- `bun run whitelist:test` passed for critical chains

## Review linkage

Follow-up for the unresolved P2 thread on [PR #28](https://github.com/ubiquity/permit2-rpc-manager/pull/28#discussion_r3663219174).